### PR TITLE
fix start and prodstart scripts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+jest.config.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,7 @@
 	"parser": "@typescript-eslint/parser",
 	"parserOptions": {
 		"ecmaVersion": "latest",
-		"sourceType": "module",
-		"project": "./tsconfig.json"
+		"sourceType": "module"
 	},
 	"extends": ["plugin:@typescript-eslint/recommended"],
 	"env": { "node": true },

--- a/__mocks__/tsconfig.json
+++ b/__mocks__/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@tsconfig/node18/tsconfig.json",
+    "compilerOptions": {
+		"experimentalDecorators": true,
+		"resolveJsonModule": true,
+    },
+	"include": ["**/*"]
+}

--- a/__tests__/tsconfig.json
+++ b/__tests__/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@tsconfig/node18/tsconfig.json",
+    "compilerOptions": {
+		"experimentalDecorators": true,
+		"resolveJsonModule": true,
+    },
+	"include": ["**/*"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+const { defaults: tsjPreset } = require('ts-jest/presets');
+
+/** @returns {Promise<import('jest').Config>} */
+
+module.exports = async () => {
+	return {
+		verbose: true,
+		modulePathIgnorePatterns: [ '<rootDir>/dist' ],
+		transform: {
+			...tsjPreset.transform,
+			'\\.[jt]s$': [
+				'ts-jest', { tsconfig: '<rootDir>/src/tsconfig.json' }
+			]
+		}
+	};
+};

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
 	"author": "Håvar Aambø Fosstveit <havar@fosstveit.net>",
 	"license": "MIT",
 	"scripts": {
-		"build": "tsc",
-		"start": "tsc && node dist/server.js",
+		"build": "tsc --build src",
+		"start": "tsc --build src && node dist/server.js",
 		"prodstart": "node dist/server.js",
 		"lint": "eslint . --ext .ts",
+		"lint:fix": "eslint . --ext .ts --fix",
 		"connect": "node connect.js",
 		"test": "jest",
 		"test:coverage": "jest --coverage --coverageDirectory coverage",
@@ -42,11 +43,5 @@
 	"optionalDependencies": {
 		"bufferutil": "^4.0.7",
 		"utf-8-validate": "^5.0.10"
-	},
-	"jest": {
-		"preset": "ts-jest",
-		"modulePathIgnorePatterns": [
-			"<rootDir>/dist"
-		]
 	}
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@tsconfig/node18/tsconfig.json",
+    "compilerOptions": {
+		"experimentalDecorators": true,
+		"resolveJsonModule": true,
+        "outDir": "../dist"
+    },
+    "include": ["**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,8 @@
 {
-	"extends": "@tsconfig/node18/tsconfig.json",
-	"compilerOptions": {
-		"experimentalDecorators": true,
-		"resolveJsonModule": true,
-		"outDir": "dist"
-	},
-	"include": ["src", "__tests__", "__mocks__/TestUtils.ts"],
-	"exclude": ["node_modules", "connect.js"]
+	"references": [
+		{"path": "./src"},
+		{"path": "./__tests__"},
+		{"path": "./__mocks__"}
+	],
+	"files": [],
 }


### PR DESCRIPTION
Closes #10 

Since we now include tests in `tsconfig.json`, implementation in /src ends up as a subfolder in /dist/src/.
Tests and mocks get compiled as well.
It breaks `start` and `prodstart` scripts in `package.json`.

This PR split `/__mocks__`, `/__tests__` and `/src` into separate typescript projects.
We can use typechecking in IDE no matter which project we work on.
when running scripts who call build, only `/src` project will be compiled.

we need to extract jest config from `package.json` and put into `jest.config.js`.
https://huafu.github.io/ts-jest/user/config/#advanced