### PR TITLE
Cascade internally based on CPU usage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,15 +42,6 @@
 			"beforeBlockComment": true,
 			"beforeLineComment": false
 		}],
-		"max-len": [ 2, 90,
-		{
-			"tabWidth": 2,
-			"comments": 90,
-			"ignoreUrls": true,
-			"ignoreStrings": true,
-			"ignoreTemplateLiterals": true,
-			"ignoreRegExpLiterals": true
-		}],
 		"newline-after-var": 2,
 		"newline-before-return": 2,
 		"newline-per-chained-call": 2,

--- a/__mocks__/WorkerMock.ts
+++ b/__mocks__/WorkerMock.ts
@@ -28,6 +28,10 @@ export default class WorkerMock extends EnhancedEventEmitter {
 		}
 	}
 
+	close = jest.fn();
+
+	getResourceUsage = jest.fn();
+
 	createWebRtcServer = jest.fn();
 	
 	createRouter = ({ mediaCodecs, appData }: RouterOptions) => {

--- a/__tests__/MediaService.startWorkers.test.ts
+++ b/__tests__/MediaService.startWorkers.test.ts
@@ -21,9 +21,11 @@ const optionsWithWorkers = {
 test('Factory method - should call startWorkers', async () => {
 	const spy = jest.spyOn(MediaService.prototype, 'startWorkers');
 
-	await MediaService.create(emptyMediaServiceOptions);
+	const ms = await MediaService.create(emptyMediaServiceOptions);
 
 	expect(spy).toHaveBeenCalled();
+
+	ms.close();
 });
 
 test('startWorkers() - should have one workers', async () => {
@@ -40,6 +42,8 @@ test('startWorkers() - should have one workers', async () => {
 
 	expect(spyCreateWorker).toHaveBeenCalled();
 	expect(sut.workers.length).toBe(1);
+
+	sut.close();
 });
 
 test('should restart worker if it dies', async () => {
@@ -58,10 +62,12 @@ test('should restart worker if it dies', async () => {
 	expect(spyRemoveWorker).toHaveBeenCalledTimes(0);
 	expect(spyAddWorker).toHaveBeenCalledTimes(1);
 
-	await mockWorker.emit('died', new Error);
+	mockWorker.emit('died', new Error);
 	
 	await TestUtils.sleep(10);
 	expect(spyRemoveWorker).toHaveBeenCalledTimes(1);
 	expect(spyAddWorker).toHaveBeenCalledTimes(2);
 	expect(sut.workers.length).toBe(1);
+
+	sut.close();
 });

--- a/__tests__/MediaService.test.ts
+++ b/__tests__/MediaService.test.ts
@@ -152,23 +152,6 @@ test('getRouter() - should not choose less load worker when router exists', asyn
 	expect(router2.appData.workerPid).toBe(1);
 });
 
-test('getRouter() - should choose other worker when load > 500', async () => {
-	const spyObserver = new EventEmitter() as unknown as EnhancedEventEmitter;
-	const sut = new MediaService(emptyMediaServiceOptions);
-	const mockWorker1 = new WorkerMock(spyObserver, 1, 500) as unknown as Worker;
-	const mockWorker2 = new WorkerMock(spyObserver, 2, 10) as unknown as Worker;
-
-	sut.workers.add(mockWorker1);
-	const router1 = await sut.getRouter('id');
-
-	sut.workers.add(mockWorker2);
-	const router2 = await sut.getRouter('id');
-
-	expect(router1.appData.workerPid).toBe(1);
-	expect(router2.appData.workerPid).toBe(2);
-
-});
-
 test('getRouter() - should use oversaturated worker if it is the least loaded in general', async () => {
 	const spyObserver = new EventEmitter() as unknown as EnhancedEventEmitter;
 	const sut = new MediaService(emptyMediaServiceOptions);

--- a/__tests__/MediaService.test.ts
+++ b/__tests__/MediaService.test.ts
@@ -208,9 +208,9 @@ test('getMetrics() - should give correct consumer count on add/remove consumer',
 	const fakeTransport = { observer: spyTransport } as unknown as Transport;
 	const fakeConsumer = { observer: spyConsumer, closed: false, id: 'id' } as unknown as Consumer;
 
-	await spyObserver.emit('newrouter', router1);
-	await spyObserver.emit('newtransport', fakeTransport);
-	await spyTransport.emit('newconsumer', fakeConsumer);
+	spyObserver.emit('newrouter', router1);
+	spyObserver.emit('newtransport', fakeTransport);
+	spyTransport.emit('newconsumer', fakeConsumer);
 
 	metrics = sut.getMetrics();
 	expect(metrics['1'].consumers).toBe(1);
@@ -219,4 +219,6 @@ test('getMetrics() - should give correct consumer count on add/remove consumer',
 	
 	metrics = sut.getMetrics();
 	expect(metrics['1'].consumers).toBe(0);
+
+	sut.close();
 });

--- a/src/MediaService.ts
+++ b/src/MediaService.ts
@@ -93,8 +93,7 @@ export default class MediaService {
 	public readonly monitor?: MediasoupMonitor;
 	private readonly cpuPollingInterval: number;
 	private readonly cpuPercentCascadingLimit: number;
-
-	private workerResourceCheckInterval: NodeJS.Timeout | undefined;
+	private workerResourceCheckInterval?: NodeJS.Timeout;
 
 	constructor({
 		ip,

--- a/src/MediaService.ts
+++ b/src/MediaService.ts
@@ -31,6 +31,8 @@ export interface WorkerData {
 	consumers: Map<string, Consumer>;
 	routersByRoomId: Map<string, Promise<Router>>;
 	webRtcServer: WebRtcServer;
+	resourceUsage: mediasoup.types.WorkerResourceUsage;
+	cpuUsage: number;
 }
 
 export interface RouterData {
@@ -66,6 +68,8 @@ export interface MediaServiceOptions {
 	numberOfWorkers: number;
 	useObserveRTC: boolean;
 	pollStatsProbability: number;
+	cpuPollingInterval: number;
+	cpuPercentCascadingLimit: number;
 }
 
 export default class MediaService {
@@ -87,6 +91,10 @@ export default class MediaService {
 	public maxOutgoingBitrate: number;
 	public workers = List<Worker>();
 	public readonly monitor?: MediasoupMonitor;
+	private readonly cpuPollingInterval: number;
+	private readonly cpuPercentCascadingLimit: number;
+
+	private workerResourceCheckInterval: NodeJS.Timeout | undefined;
 
 	constructor({
 		ip,
@@ -96,6 +104,8 @@ export default class MediaService {
 		maxOutgoingBitrate,
 		useObserveRTC,
 		pollStatsProbability,
+		cpuPollingInterval,
+		cpuPercentCascadingLimit,
 	}: MediaServiceOptions) {
 		logger.debug('constructor()');
 
@@ -105,6 +115,8 @@ export default class MediaService {
 		this.maxIncomingBitrate = maxIncomingBitrate;
 		this.maxOutgoingBitrate = maxOutgoingBitrate;
 		this.monitor = useObserveRTC ? this.createMonitor(pollStatsProbability) : undefined;
+		this.cpuPollingInterval = cpuPollingInterval;
+		this.cpuPercentCascadingLimit = cpuPercentCascadingLimit;
 	}
 
 	@skipIfClosed
@@ -112,6 +124,8 @@ export default class MediaService {
 		logger.debug('close()');
 
 		this.closed = true;
+
+		clearInterval(this.workerResourceCheckInterval);
 
 		this.workers.items.forEach((w) => w.close());
 		this.workers.clear();
@@ -200,6 +214,7 @@ export default class MediaService {
 					appData: {
 						consumers: new Map<string, Consumer>(),
 						routersByRoomId: new Map<string, Promise<Router>>(),
+						cpuUsage: 0,
 					}
 				} as WorkerSettings;
 			} else {
@@ -209,12 +224,38 @@ export default class MediaService {
 					appData: {
 						consumers: new Map<string, Consumer>(),
 						routersByRoomId: new Map<string, Promise<Router>>(),
+						cpuUsage: 0,
 					}
 				} as WorkerSettings;
 			}
 
 			await this.startWorker(settings);
 		}
+
+		this.workerResourceCheckInterval = setInterval(async () => {
+			const resourses = await Promise.allSettled(
+				this.workers.items.map((w) => w.getResourceUsage())
+			);
+
+			resourses.forEach((result, index) => {
+				if (result.status === 'fulfilled') {
+					const worker = this.workers.items[index];
+					const workerData = worker.appData as unknown as WorkerData;
+
+					// eslint-disable-next-line camelcase
+					const { ru_utime: oldRuUtime, ru_stime: oldRuStime } = workerData.resourceUsage ?? { ru_utime: 0, ru_stime: 0 };
+					// eslint-disable-next-line camelcase
+					const { ru_utime: newRuUtime, ru_stime: newRuStime } = result.value;
+
+					workerData.cpuUsage = ((newRuUtime + newRuStime - oldRuUtime - oldRuStime) / this.cpuPollingInterval) * 100;
+					workerData.resourceUsage = result.value;
+
+					logger.debug('startWorkers() worker resource usage [workerPid: %s, cpuUsage: %s]', worker.pid, workerData.cpuUsage);
+				} else {
+					logger.error('startWorkers() error getting worker resource usage [error: %o]', result.reason);
+				}
+			});
+		}, 10_000);
 	}
 
 	@skipIfClosed
@@ -313,8 +354,8 @@ export default class MediaService {
 
 		// Create a new array, we don't want to mutate the original one
 		const leastLoadedWorkers = [ ...this.workers.items ].sort((a, b) =>
-			(a.appData as unknown as WorkerData).consumers.size -
-			(b.appData as unknown as WorkerData).consumers.size);
+			(a.appData as unknown as WorkerData).cpuUsage -
+			(b.appData as unknown as WorkerData).cpuUsage);
 
 		if (roomRouters.length === 0) {
 			logger.debug('getRouter() first client [roomId: %s]', roomId);
@@ -330,13 +371,12 @@ export default class MediaService {
 		const leastLoadedRoomWorkerData =
 			leastLoadedRoomWorkers[0].appData as unknown as WorkerData;
 
-		// Consumer count is the best measurement available for load
-		// 500 has proven to be a good break point.
-		if (leastLoadedRoomWorkerData.consumers.size < 500) {
+		// CPU usage is below the cascading limit, use the least loaded room worker
+		if (leastLoadedRoomWorkerData.cpuUsage < this.cpuPercentCascadingLimit) {
 			logger.debug(
-				'getRouter() worker has capacity [roomId: %s, load: %s]',
+				'getRouter() worker has capacity [roomId: %s, cpuUsage: %s]',
 				roomId,
-				leastLoadedRoomWorkerData.consumers.size
+				leastLoadedRoomWorkerData.cpuUsage
 			);
 
 			return this.getOrCreateRouterPromise(roomId, leastLoadedRoomWorkers[0]);
@@ -347,31 +387,31 @@ export default class MediaService {
 
 		if (leastLoadedRoomWorkers[0].pid === leastLoadedWorkers[0].pid) {
 			logger.debug(
-				'getRouter() room worker least loaded [roomId: %s, load: %s]',
+				'getRouter() room worker least loaded [roomId: %s, cpuUsage: %s]',
 				roomId,
-				leastLoadedRoomWorkerData.consumers.size
+				leastLoadedRoomWorkerData.cpuUsage
 			);
 
 			return this.getOrCreateRouterPromise(roomId, leastLoadedRoomWorkers[0]);
 		}
 
 		if (
-			leastLoadedRoomWorkerData.consumers.size -
-			leastLoadedWorkerData.consumers.size < 100
+			leastLoadedRoomWorkerData.cpuUsage -
+			leastLoadedWorkerData.cpuUsage < 10
 		) {
 			logger.debug(
-				'getRouter() low delta [roomId: %s, load: %s]',
+				'getRouter() low delta [roomId: %s, cpuUsage: %s]',
 				roomId,
-				leastLoadedRoomWorkerData.consumers.size
+				leastLoadedRoomWorkerData.cpuUsage
 			);
 
 			return this.getOrCreateRouterPromise(roomId, leastLoadedRoomWorkers[0]);
 		}
 
 		logger.debug(
-			'getRouter() last resort [roomId: %s, load: %s]',
+			'getRouter() last resort [roomId: %s, cpuUsage: %s]',
 			roomId,
-			leastLoadedWorkerData.consumers.size
+			leastLoadedWorkerData.cpuUsage
 		);
 
 		return this.getOrCreateRouterPromise(roomId, leastLoadedWorkers[0]);

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,10 @@ const showUsage = () => {
 	logger.debug('    Flag indicate to use ObserveRTC plugin for monitoring the SFU.\n\n');
 	logger.debug('  --pollStatsProbability <[0..1]> (optional, default: 1.0)');
 	logger.debug('    The probability of polling stats by the monitor from transports, producers, consumers, dataProducers or dataConsumers.\n\n');
+	logger.debug('  --cpuPollingInterval <ms> (optional, default: 10000)');
+	logger.debug('    The interval in ms to poll CPU usage.\n\n');
+	logger.debug('  --cpuPercentCascadingLimit <percent> (optional, default: 66)');
+	logger.debug('    The CPU usage percent limit to start cascading.\n\n');
 };
 
 (async () => {
@@ -67,6 +71,8 @@ const showUsage = () => {
 		numberOfWorkers = os.cpus().length,
 		useObserveRTC = true,
 		pollStatsProbability = 1.0,
+		cpuPollingInterval = 10_000,
+		cpuPercentCascadingLimit = 66,
 	} = minimist(process.argv.slice(2));
 	
 	if (!ip || help || usage) {
@@ -93,6 +99,8 @@ const showUsage = () => {
 		numberOfWorkers,
 		useObserveRTC,
 		pollStatsProbability,
+		cpuPollingInterval,
+		cpuPercentCascadingLimit,
 	}).catch((error) => {
 		logger.error('MediaService creation failed: %o', error);
 


### PR DESCRIPTION
Instead of counting the number of consumers on a worker we now check the actual CPU usage of the worker before deciding to spread a room to a new worker.