### PR TITLE
build/remove-stupid-ci-skip [skip ci]

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, '#skip') }}
 
     strategy:
       matrix:


### PR DESCRIPTION
This PR will:
* Remove a stupid ci skip line in github workflows