### PR TITLE
log warning on null layers

### DIFF
--- a/src/middlewares/consumerMiddleware.ts
+++ b/src/middlewares/consumerMiddleware.ts
@@ -190,14 +190,17 @@ export const createConsumerMiddleware = ({
 					}
 				}));
 		
-				consumer.on('layerschange', (layers) => roomServerConnection.notify({
-					method: 'consumerLayersChanged',
-					data: {
-						routerId,
-						consumerId: consumer.id,
-						layers
-					}
-				}));
+				consumer.on('layerschange', (layers) => {
+					if (!layers) logger.warn('layerschange event with null layers');
+					roomServerConnection.notify({
+						method: 'consumerLayersChanged',
+						data: {
+							routerId,
+							consumerId: consumer.id,
+							layers
+						}
+					}); 
+				});
 
 				response.id = consumer.id;
 				response.kind = consumer.kind;


### PR DESCRIPTION
This PR will add a warning log message when consumer emits layerschange with null layers.

"When there is no available bitrate for this consumer (even for the lowest layers) so the event fires with null as argument."
https://mediasoup.org/documentation/v3/mediasoup/api/#consumer-on-layerschange