### PR TITLE
feat: add samples upload URI parser with S3 and HTTP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,189 @@ $ DEBUG=edumeet:* yarn start --ip <public-ip-of-host> --secret <secret-shared-wi
 ```
 ### Docker
 https://github.com/edumeet/edumeet-docker/tree/4.x has guidelines for running the next generation Edumeet as docker containers.
+
+## observertc sample storage
+
+Clients send [observertc](https://github.com/ObserveRTC) `ClientSample` payloads over the
+`observertc-samples` data channel. The media node feeds them into an observer that correlates
+them with mediasoup's own router samples, and turns the result into three kinds of artifact:
+
+| Artifact | When it is produced | Content type |
+| --- | --- | --- |
+| `<clientId>.jsonl` | an observed client leaves and its sink closes | `application/x-ndjson` |
+| `call-summary.json` | a call closes | `application/json` |
+| `mediasoup-router-<routerId>.json` | a router is removed | `application/json` |
+
+Nothing is stored or uploaded unless you ask for it. With neither option set, samples are
+accepted, processed, and dropped.
+
+### Options
+
+| Option | Purpose |
+| --- | --- |
+| `--samplesStorePath <path>` | Local directory for the per-client JSONL files. |
+| `--samplesUploadUri <uri>` | Upload destination for all artifacts. |
+
+| `samplesStorePath` | `samplesUploadUri` | Behaviour |
+| --- | --- | --- |
+| unset | unset | Samples are processed, then dropped. |
+| set | unset | JSONL files are written locally and kept. |
+| unset | set | Upload target is ignored, with a warning. |
+| set | set | JSONL files are staged locally and uploaded; call summaries and router samples are uploaded too. |
+
+**`--samplesStorePath` is required for uploading.** The observer only creates a file sink when it
+has somewhere to write, and the uploader sends that file, so without a directory there is nothing
+per-client to upload. An upload URI given without a store path is discarded with a warning.
+
+The node does not invent a temporary directory for you. It cannot know what the host or pod can
+spare, and a read-only root filesystem or an ephemeral-storage limit would turn that guess into a
+crash or an eviction.
+
+### Retention
+
+The media node does **not** implement retention. There is no age cap, no size cap, and no
+background sweep.
+
+- With an upload URI configured, `deleteAfterUpload` defaults to `true`, so the store path is a
+  staging area and does not accumulate files.
+- Without an upload URI, files are written and left alone. Deciding what to keep is the storage
+  layer's job — volume retention, a log-rotation sidecar, or bucket lifecycle rules. Point
+  `--samplesStorePath` at a volume you are willing to let grow, and manage it there.
+
+### deleteAfterUpload
+
+Controls whether a staged local file is removed once it has been uploaded.
+
+- **Defaults to `true`** whenever an upload URI is configured.
+- Set `?deleteAfterUpload=false` to keep local copies as well.
+- Deletion happens only after the upload **succeeds**. A failed upload keeps the file.
+- Deletion applies to file-based artifacts, which today means the per-client JSONL sink files.
+  Call summaries and router samples are generated in memory and never staged.
+- Deletion errors are logged as warnings and never interrupt the node.
+
+### samplesUploadUri formats
+
+| Scheme | Target |
+| --- | --- |
+| `s3://`, or a bare bucket name | S3 or S3-compatible storage (MinIO, Ceph, ...). |
+| `http://`, `https://` | HTTP collector, one POST per artifact. |
+
+#### S3
+
+```
+s3://<bucket>[/<keyPrefix>][?<param>=<value>&...]
+```
+
+| Parameter | Default | Notes |
+| --- | --- | --- |
+| `endpoint` | AWS endpoint | Custom S3-compatible endpoint URL. Must be `http://` or `https://`. |
+| `region` | `AWS_REGION`, then `AWS_DEFAULT_REGION`, then `us-east-1` when an endpoint is set | Region passed to the SDK. |
+| `pathStyle` | `true` when `endpoint` is set, otherwise `false` | Path-style vs virtual-host-style addressing. MinIO needs path-style. |
+| `credentialsEnv` | none | Reads `<PREFIX>_ACCESS_KEY_ID` and `<PREFIX>_SECRET_ACCESS_KEY`, plus optional `<PREFIX>_SESSION_TOKEN`. |
+| `maxAttempts` | SDK default | Retry attempts, integer >= 1. |
+| `deleteAfterUpload` | `true` | Delete the staged JSONL file after a successful upload. |
+
+#### HTTP
+
+```
+http[s]://<host>[:<port>][/<basePath>][?<param>=<value>&...]
+```
+
+| Parameter | Default | Notes |
+| --- | --- | --- |
+| `credentialsEnv` | none | Reads a bearer token from `<PREFIX>_TOKEN`. |
+| `maxAttempts` | `3` | Retry attempts, integer >= 1. |
+| `deleteAfterUpload` | `true` | Delete the staged JSONL file after a successful upload. |
+
+Unknown parameters are rejected per scheme, so a typo like `?regoin=eu-north-1` is reported rather
+than silently ignored.
+
+### Credentials
+
+**Credentials are never read from the URI.** `s3://key:secret@bucket` and
+`https://user:pass@host` are rejected outright — a URI ends up in `ps` output, pod specs, shell
+history and logs.
+
+Use `?credentialsEnv=<PREFIX>` to name environment variables instead:
+
+| Target | Variables |
+| --- | --- |
+| S3 | `<PREFIX>_ACCESS_KEY_ID`, `<PREFIX>_SECRET_ACCESS_KEY`, optional `<PREFIX>_SESSION_TOKEN` |
+| HTTP | `<PREFIX>_TOKEN`, sent as `Authorization: Bearer ...` |
+
+Without `credentialsEnv`, S3 falls back to the AWS SDK default credential chain: IRSA, instance
+roles, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, `~/.aws/credentials`. On a properly annotated
+Kubernetes service account you usually need no credential configuration at all.
+
+At startup the resolved configuration is logged with credentials shown as a reference
+(`env:MINIO_*`), never as a value.
+
+### Object keys
+
+Keys are identical across S3 and HTTP targets:
+
+```
+<roomId>/<callId>/<clientId>.jsonl
+<roomId>/<callId>/call-summary.json
+<roomId>/<callId>/mediasoup-router-<routerId>.json
+```
+
+For S3, a `keyPrefix` from the URI path is prepended. For HTTP, the key is appended to the base
+path, one POST per artifact.
+
+`roomId` arrives in a client-supplied sample attachment, so it is validated before use: it must
+match `[A-Za-z0-9._-]{1,128}` and may not be `.` or `..`. Anything else, including a room that was
+never reported, falls back to `unknown-room` and logs a warning. This keeps a hostile client from
+polluting the key space or escaping the configured HTTP base path.
+
+### Failure behaviour
+
+- A malformed `--samplesUploadUri` **does not stop the node**. It logs a warning naming the
+  problem and starts with uploads disabled.
+- Upload failures are logged. The artifact is lost, calls are unaffected. There is no queue, no
+  spooling, and no replay after a restart.
+- HTTP retries network errors, `429` and `5xx` with exponential backoff up to `maxAttempts`, with
+  a 30 second per-request timeout. Other `4xx` responses fail immediately, since retrying a
+  rejected request will not help.
+- S3 delegates retries to the AWS SDK.
+
+### Examples
+
+Local storage only, no upload:
+
+```bash
+yarn start --ip <public-ip> \
+  --samplesStorePath /var/lib/edumeet/samples
+```
+
+AWS S3, credentials from the instance role or IRSA:
+
+```bash
+yarn start --ip <public-ip> \
+  --samplesStorePath /var/lib/edumeet/samples \
+  --samplesUploadUri "s3://edumeet-samples/prod?region=eu-north-1"
+```
+
+MinIO inside the cluster, credentials from environment variables:
+
+```bash
+export MINIO_ACCESS_KEY_ID=...
+export MINIO_SECRET_ACCESS_KEY=...
+
+yarn start --ip <public-ip> \
+  --samplesStorePath /var/lib/edumeet/samples \
+  --samplesUploadUri "s3://samples/dev?endpoint=http://minio.minio-ns.svc.cluster.local:9000&credentialsEnv=MINIO"
+```
+
+HTTP collector with a bearer token, keeping local copies:
+
+```bash
+export COLLECTOR_TOKEN=...
+
+yarn start --ip <public-ip> \
+  --samplesStorePath /var/lib/edumeet/samples \
+  --samplesUploadUri "https://collector.example.com/observertc?credentialsEnv=COLLECTOR&deleteAfterUpload=false"
+```
+
+When passing a URI through a shell or a Kubernetes manifest, quote it. An unquoted `&` between
+query parameters is a shell control character and will truncate the value.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ http[s]://<host>[:<port>][/<basePath>][?<param>=<value>&...]
 | `deleteAfterUpload` | `true` | Delete the staged JSONL file after a successful upload. |
 
 Unknown parameters are rejected per scheme, so a typo like `?regoin=eu-north-1` is reported rather
-than silently ignored.
+than silently ignored. A URI fragment is rejected for the same reason: a fragment is never sent in
+an HTTP request, so a base like `https://collector.example.com/observertc#prod` would quietly POST
+to `/observertc` instead of where it appears to point.
 
 ### Credentials
 
@@ -168,6 +170,8 @@ polluting the key space or escaping the configured HTTP base path.
 
 - A malformed `--samplesUploadUri` **does not stop the node**. It logs a warning naming the
   problem and starts with uploads disabled.
+- `--samplesStorePath` passed without a value, or with a blank one, is treated the same way:
+  sample storage is disabled with a warning, and any upload URI alongside it is discarded.
 - Upload failures are logged. The artifact is lost, calls are unaffected. There is no queue, no
   spooling, and no replay after a restart.
 - HTTP retries network errors, `429` and `5xx` with exponential backoff up to `maxAttempts`, with

--- a/__tests__/unit-tests/MediaService.test.ts
+++ b/__tests__/unit-tests/MediaService.test.ts
@@ -5,13 +5,11 @@ import * as mediasoup from 'mediasoup';
 jest.mock('mediasoup');
 // import { Worker } from 'mediasoup/node/lib/Worker';
 // jest.mock('mediasoup/node/lib/Worker');
-jest.mock('@observertc/sfu-monitor-js');
 
 type Worker = any;
 
 import 'jest';
 import MediaService, { MediaServiceOptions, WorkerData } from '../../src/MediaService';
-import * as observeRtcMock from '@observertc/sfu-monitor-js';
 import WorkerMock from '../../__mocks__/WorkerMock';
 import EventEmitter from 'events';
 import { EnhancedEventEmitter } from 'mediasoup/node/lib/EnhancedEventEmitter';
@@ -25,65 +23,8 @@ const optionsWithWorkers = {
 	numberOfWorkers: 1 
 } as unknown as MediaServiceOptions;
 
-const createMonitorSpy = jest
-	.spyOn(observeRtcMock, 'createMediasoupMonitor')
-	.mockReturnValue({} as unknown as observeRtcMock.MediasoupMonitor);
-
 test('Constructor - should not throw', () => {
 	expect(() => new MediaService(emptyMediaServiceOptions)).not.toThrow();
-});
-
-test('useObserveRTC - should create MediasoupMonitor and not use random when pollStatsProbability <= 0.0', () => {
-	const randomSpy = jest.spyOn(Math, 'random');
-	const useObserveRTCOptions = {
-		useObserveRTC: true,
-		pollStatsProbability: 0.0,
-	} as unknown as MediaServiceOptions;
-
-	const sut = new MediaService(useObserveRTCOptions);
-
-	expect(createMonitorSpy).toHaveBeenCalledTimes(1);
-	expect(sut.monitor).not.toBeUndefined();
-	expect(randomSpy).not.toHaveBeenCalled();
-
-	createMonitorSpy.mockClear();
-	randomSpy.mockRestore();
-});
-
-test('useObserveRTC - should create MediasoupMonitor and not use random when pollStatsProbability > 1.0', () => {
-	const randomSpy = jest.spyOn(Math, 'random');
-	const useObserveRTCOptions = {
-		useObserveRTC: true,
-		pollStatsProbability: 1.1,
-	} as unknown as MediaServiceOptions;
-
-	const sut = new MediaService(useObserveRTCOptions);
-
-	expect(createMonitorSpy).toHaveBeenCalledTimes(1);
-	expect(sut.monitor).not.toBeUndefined();
-	expect(randomSpy).not.toHaveBeenCalled();
-
-	createMonitorSpy.mockClear();
-	randomSpy.mockRestore();
-});
-
-test('useObserveRTC - should create MediasoupMonitor when 0.0 < pollStatsProbability < 1.0', () => {
-	const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.4);
-	const useObserveRTCOptions = {
-		useObserveRTC: true,
-		pollStatsProbability: 0.5,
-	} as unknown as MediaServiceOptions;
-
-	const sut = new MediaService(useObserveRTCOptions);
-
-	expect(createMonitorSpy).toHaveBeenCalledTimes(1);
-	expect(sut.monitor).not.toBeUndefined();
-
-	// With current MediaService implementation, Math.random() is not invoked during monitor creation.
-	expect(randomSpy).toHaveBeenCalledTimes(0);
-
-	createMonitorSpy.mockClear();
-	randomSpy.mockRestore();
 });
 
 test('Close() - Should close', () => {

--- a/__tests__/unit-tests/ObserverService.test.ts
+++ b/__tests__/unit-tests/ObserverService.test.ts
@@ -1,0 +1,313 @@
+import { JsonlFileSink } from '@observertc/observer-js';
+import { access, mkdtemp, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ObserverService } from '../../src/ObserverService';
+import { Uploader, UploadOptions } from '../../src/uploader/Uploader';
+
+const stubUploader = (deleteAfterUpload: boolean, fail = false) => {
+	const calls: UploadOptions[] = [];
+	const uploader: Uploader = {
+		deleteAfterUpload,
+		upload: async (options: UploadOptions) => {
+			calls.push(options);
+
+			if (fail) throw new Error('upload boom');
+		},
+	};
+
+	return { uploader, calls };
+};
+
+/** Poll rather than sleep, so we do not race the sink's async close handling. */
+const until = async (check: () => Promise<boolean>, timeoutMs = 3000): Promise<boolean> => {
+	const deadline = Date.now() + timeoutMs;
+
+	while (Date.now() < deadline) {
+		if (await check()) return true;
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+
+	return false;
+};
+
+const exists = async (path: string): Promise<boolean> => {
+	try {
+		await access(path);
+
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/** Drive one client sink through create -> close, as the observer would. */
+const runSinkLifecycle = async (uploader: Uploader) => {
+	const directory = await mkdtemp(join(tmpdir(), 'observer-service-'));
+	const sourcePath = join(directory, 'client.jsonl');
+
+	await writeFile(sourcePath, '{"n":1}\n');
+
+	const service = new ObserverService({ samplesStorePath: directory, uploader });
+	const sink = new JsonlFileSink({ path: sourcePath });
+	const scope = {
+		sink,
+		observedCall: { callId: 'call-1', appData: { roomId: 'room-1' } },
+		observedClient: { clientId: 'client-1', attachments: {} },
+	};
+
+	service.emit('client-sink-created', scope as never);
+	sink.end();
+
+	return { sourcePath };
+};
+
+describe('ObserverService - uploader wiring', () => {
+	test('discards an uploader that has no directory to read from', () => {
+		const { uploader } = stubUploader(false);
+		const service = new ObserverService({ uploader });
+
+		expect(service.options.uploader).toBeUndefined();
+		expect(service.listenerCount('call-closed')).toBe(0);
+	});
+
+	test('subscribes to the artifact events only when uploading', () => {
+		const { uploader } = stubUploader(false);
+		const withUploader = new ObserverService({ samplesStorePath: tmpdir(), uploader });
+		const without = new ObserverService({ samplesStorePath: tmpdir() });
+
+		for (const event of [ 'client-sink-created', 'client-added', 'client-updated', 'call-closed', 'mediasoup-router-removed' ]) {
+			expect(withUploader.listenerCount(event as never)).toBe(1);
+			expect(without.listenerCount(event as never)).toBe(0);
+		}
+
+		// Diagnostics stay wired either way.
+		expect(without.listenerCount('peer-connection-added' as never)).toBe(1);
+	});
+});
+
+describe('ObserverService - staged file cleanup', () => {
+	test('uploads the sink file under the room/call/client key', async () => {
+		const { uploader, calls } = stubUploader(false);
+		const { sourcePath } = await runSinkLifecycle(uploader);
+
+		expect(await until(async () => calls.length > 0)).toBe(true);
+		expect(calls[0]).toMatchObject({
+			key: 'room-1/call-1/client-1.jsonl',
+			sourcePath,
+			contentType: 'application/x-ndjson',
+		});
+	});
+
+	test('deletes the file when the uploader asks for it', async () => {
+		const { uploader, calls } = stubUploader(true);
+		const { sourcePath } = await runSinkLifecycle(uploader);
+
+		expect(await until(async () => calls.length > 0)).toBe(true);
+		expect(await until(async () => !(await exists(sourcePath)))).toBe(true);
+	});
+
+	test('keeps the file when deleteAfterUpload is off', async () => {
+		const { uploader, calls } = stubUploader(false);
+		const { sourcePath } = await runSinkLifecycle(uploader);
+
+		expect(await until(async () => calls.length > 0)).toBe(true);
+
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		expect(await exists(sourcePath)).toBe(true);
+	});
+
+	test('keeps the file when the upload failed, even with deletion on', async () => {
+		const { uploader, calls } = stubUploader(true, true);
+		const { sourcePath } = await runSinkLifecycle(uploader);
+
+		expect(await until(async () => calls.length > 0)).toBe(true);
+
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		expect(await exists(sourcePath)).toBe(true);
+	});
+});
+
+/** Minimal stand-ins for the observer scopes; only the fields the handlers read. */
+const callScope = (overrides: Record<string, unknown> = {}) => ({
+	callId: 'call-1',
+	numberOfIssues: 2,
+	clientsUsedTurn: new Set([ 'client-1' ]),
+	appData: { roomId: 'room-1', clients: {}, routerIds: [] as string[] },
+	...overrides,
+});
+
+describe('ObserverService - appData bookkeeping', () => {
+	const service = () => new ObserverService({ samplesStorePath: tmpdir(), uploader: stubUploader(false).uploader });
+
+	test('client-added seeds the client entry', () => {
+		const svc = service();
+		const observedCall = callScope();
+
+		svc.emit('client-added', { observedCall, observedClient: { clientId: 'client-1' } } as never);
+
+		expect(observedCall.appData.clients).toHaveProperty('client-1');
+	});
+
+	test('client-updated lifts roomId and displayName off the attachments', () => {
+		const svc = service();
+		const observedCall = callScope({ appData: { roomId: undefined, clients: { 'client-1': {} }, routerIds: [] } });
+		const observedClient = {
+			clientId: 'client-1',
+			call: observedCall,
+			attachments: { roomId: 'room-9', displayName: 'Ada' },
+		};
+
+		svc.emit('client-updated', { observedClient } as never);
+
+		expect(observedCall.appData.roomId).toBe('room-9');
+		expect(observedCall.appData.clients['client-1']).toEqual({ displayName: 'Ada' });
+	});
+
+	test('router matching tags the client and records the router on the call', () => {
+		const svc = service();
+		const observedCall = callScope();
+		const injectAttachment = jest.fn();
+		const observedMediasoupRouter = { router: { id: 'router-1' }, appData: undefined as unknown };
+
+		svc.emit('mediasoup-router-matched-with-peer-connection', {
+			observedClient: { clientId: 'client-1', injectAttachment },
+			observedCall,
+			observedMediasoupRouter,
+		} as never);
+
+		expect(injectAttachment).toHaveBeenCalledWith({ routerId: 'router-1' });
+		expect(observedCall.appData.routerIds).toEqual([ 'router-1' ]);
+		expect(observedMediasoupRouter.appData).toEqual({ observedCall });
+	});
+
+	test('router matching does not record the same router twice', () => {
+		const svc = service();
+		const observedCall = callScope();
+		const scope = {
+			observedClient: { clientId: 'client-1', injectAttachment: jest.fn() },
+			observedCall,
+			observedMediasoupRouter: { router: { id: 'router-1' }, appData: undefined as unknown },
+		};
+
+		svc.emit('mediasoup-router-matched-with-peer-connection', scope as never);
+		svc.emit('mediasoup-router-matched-with-peer-connection', scope as never);
+
+		expect(observedCall.appData.routerIds).toEqual([ 'router-1' ]);
+	});
+});
+
+describe('ObserverService - summary and router uploads', () => {
+	test('call-closed uploads the summary with issues and turn usage', async () => {
+		const { uploader, calls } = stubUploader(false);
+		const svc = new ObserverService({ samplesStorePath: tmpdir(), uploader });
+
+		svc.emit('call-closed', { observedCall: callScope() } as never);
+
+		expect(await until(async () => calls.length > 0)).toBe(true);
+		expect(calls[0].key).toBe('room-1/call-1/call-summary.json');
+		expect(calls[0].contentType).toBe('application/json');
+		expect(JSON.parse(String(calls[0].body))).toMatchObject({
+			roomId: 'room-1',
+			numberOfIssues: 2,
+			clientsUsedTurn: [ 'client-1' ],
+		});
+	});
+
+	test('call-closed falls back to unknown-room', async () => {
+		const { uploader, calls } = stubUploader(false);
+		const svc = new ObserverService({ samplesStorePath: tmpdir(), uploader });
+
+		svc.emit('call-closed', { observedCall: callScope({ appData: { roomId: undefined, clients: {}, routerIds: [] } }) } as never);
+
+		expect(await until(async () => calls.length > 0)).toBe(true);
+		expect(calls[0].key).toBe('unknown-room/call-1/call-summary.json');
+	});
+
+	test('router-removed uploads the router sample', async () => {
+		const { uploader, calls } = stubUploader(false);
+		const svc = new ObserverService({ samplesStorePath: tmpdir(), uploader });
+
+		svc.emit('mediasoup-router-removed', {
+			observedMediasoupRouter: {
+				router: { id: 'router-1' },
+				sample: { some: 'stats' },
+				appData: { observedCall: callScope() },
+			},
+		} as never);
+
+		expect(await until(async () => calls.length > 0)).toBe(true);
+		expect(calls[0].key).toBe('room-1/call-1/mediasoup-router-router-1.json');
+		expect(JSON.parse(String(calls[0].body))).toEqual({ some: 'stats' });
+	});
+
+	test('router-removed skips a router that was never matched to a call', async () => {
+		const { uploader, calls } = stubUploader(false);
+		const svc = new ObserverService({ samplesStorePath: tmpdir(), uploader });
+
+		svc.emit('mediasoup-router-removed', {
+			observedMediasoupRouter: { router: { id: 'router-1' }, sample: {}, appData: undefined },
+		} as never);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(calls).toHaveLength(0);
+	});
+
+	test('diagnostic handlers do not throw', () => {
+		const svc = new ObserverService({ samplesStorePath: tmpdir() });
+
+		expect(() => svc.emit('peer-connection-added', {
+			observedCall: callScope(),
+			observedClient: { clientId: 'client-1' },
+			observedPeerConnection: { peerConnectionId: 'pc-1' },
+		} as never)).not.toThrow();
+
+		expect(() => svc.emit('mediasoup-router-added', {
+			observedMediasoupRouter: { router: { id: 'router-1' }, sample: {} },
+		} as never)).not.toThrow();
+	});
+});
+
+describe('ObserverService - addDataConsumer', () => {
+	/* eslint-disable-next-line no-unused-vars */
+	type MessageHandler = (payload: Buffer | string) => void;
+
+	const fakeDataConsumer = () => {
+		const handlers: Record<string, MessageHandler> = {};
+
+		return {
+			id: 'dc-1',
+			on: jest.fn((event: string, handler: MessageHandler) => {
+				handlers[event] = handler;
+			}),
+			off: jest.fn(),
+			observer: { once: jest.fn() },
+			handlers,
+		};
+	};
+
+	test('subscribes to messages and unsubscribes when the consumer closes', () => {
+		const svc = new ObserverService({});
+		const dataConsumer = fakeDataConsumer();
+
+		svc.addDataConsumer(dataConsumer as never);
+
+		expect(dataConsumer.on).toHaveBeenCalledWith('message', expect.any(Function));
+		expect(dataConsumer.observer.once).toHaveBeenCalledWith('close', expect.any(Function));
+
+		// Fire the registered close handler and confirm it detaches the listener.
+		(dataConsumer.observer.once.mock.calls[0][1] as () => void)();
+		expect(dataConsumer.off).toHaveBeenCalledWith('message', expect.any(Function));
+	});
+
+	test('survives a payload that is not valid JSON', () => {
+		const svc = new ObserverService({});
+		const dataConsumer = fakeDataConsumer();
+
+		svc.addDataConsumer(dataConsumer as never);
+
+		expect(() => dataConsumer.handlers.message(Buffer.from('not json'))).not.toThrow();
+		expect(() => dataConsumer.handlers.message('also not json')).not.toThrow();
+	});
+});

--- a/__tests__/unit-tests/ObserverService.test.ts
+++ b/__tests__/unit-tests/ObserverService.test.ts
@@ -2,7 +2,7 @@ import { JsonlFileSink } from '@observertc/observer-js';
 import { access, mkdtemp, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { ObserverService } from '../../src/ObserverService';
+import { ObservedCallAppData, ObserverService } from '../../src/ObserverService';
 import { Uploader, UploadOptions } from '../../src/uploader/Uploader';
 
 const stubUploader = (deleteAfterUpload: boolean, fail = false) => {
@@ -130,11 +130,18 @@ describe('ObserverService - staged file cleanup', () => {
 });
 
 /** Minimal stand-ins for the observer scopes; only the fields the handlers read. */
-const callScope = (overrides: Record<string, unknown> = {}) => ({
+type CallScope = {
+	callId: string;
+	numberOfIssues: number;
+	clientsUsedTurn: Set<string>;
+	appData: ObservedCallAppData;
+};
+
+const callScope = (overrides: Partial<CallScope> = {}): CallScope => ({
 	callId: 'call-1',
 	numberOfIssues: 2,
 	clientsUsedTurn: new Set([ 'client-1' ]),
-	appData: { roomId: 'room-1', clients: {}, routerIds: [] as string[] },
+	appData: { roomId: 'room-1', clients: {}, routerIds: [] },
 	...overrides,
 });
 

--- a/__tests__/unit-tests/ObserverService.test.ts
+++ b/__tests__/unit-tests/ObserverService.test.ts
@@ -87,6 +87,42 @@ describe('ObserverService - uploader wiring', () => {
 	});
 });
 
+describe('ObserverService - options handling', () => {
+	test('never writes to the options object it was handed', () => {
+		const { uploader } = stubUploader(false);
+		const options = { uploader };
+		const service = new ObserverService(options);
+
+		// The uploader is dropped for want of a store path, but only internally:
+		// the caller may well reuse this object for a second service.
+		expect(options.uploader).toBe(uploader);
+		expect(service.options).not.toBe(options);
+		expect(service.options.uploader).toBeUndefined();
+	});
+
+	// minimist yields `true` for a valueless `--samplesStorePath`, and handing
+	// that to the file sink factory used to take the node down at startup.
+	test('disables storage for a valueless --samplesStorePath instead of throwing', () => {
+		const { uploader } = stubUploader(false);
+		const service = new ObserverService({ samplesStorePath: true, uploader });
+
+		expect(service.options.samplesStorePath).toBeUndefined();
+		expect(service.options.uploader).toBeUndefined();
+		expect(service.listenerCount('client-sink-created')).toBe(0);
+	});
+
+	test('disables storage for a blank --samplesStorePath', () => {
+		expect(new ObserverService({ samplesStorePath: '' }).options.samplesStorePath).toBeUndefined();
+		expect(new ObserverService({ samplesStorePath: '   ' }).options.samplesStorePath).toBeUndefined();
+		expect(new ObserverService({ samplesStorePath: 42 }).options.samplesStorePath).toBeUndefined();
+	});
+
+	test('keeps a usable path, trimmed', () => {
+		expect(new ObserverService({ samplesStorePath: ` ${tmpdir()} ` }).options.samplesStorePath).toBe(tmpdir());
+		expect(new ObserverService({ samplesStorePath: tmpdir() }).listenerCount('client-sink-created')).toBe(1);
+	});
+});
+
 describe('ObserverService - staged file cleanup', () => {
 	test('uploads the sink file under the room/call/client key', async () => {
 		const { uploader, calls } = stubUploader(false);

--- a/__tests__/unit-tests/uploader/Uploader.test.ts
+++ b/__tests__/unit-tests/uploader/Uploader.test.ts
@@ -344,19 +344,32 @@ describe('createUploader - credential resolution failures', () => {
 });
 
 describe('S3Uploader - client configuration', () => {
-	const clientOf = (uploader: S3Uploader): S3Client =>
-		(uploader as unknown as { client: S3Client }).client;
+	// The AWS SDK is imported on first upload, so the client does not exist until
+	// `ensureSdk()` has run. These tests force that load rather than uploading.
+	const clientOf = async (uploader: S3Uploader): Promise<S3Client> => {
+		await (uploader as unknown as { ensureSdk(): Promise<unknown> }).ensureSdk();
+
+		return (uploader as unknown as { client: S3Client }).client;
+	};
 
 	test('applies region and path style from the URI', async () => {
 		const uploader = new S3Uploader(s3Config('s3://bucket?endpoint=http://minio:9000&region=eu-north-1'));
-		const { config } = clientOf(uploader);
+		const { config } = await clientOf(uploader);
 
 		expect(await config.region()).toBe('eu-north-1');
 		expect(config.forcePathStyle).toBe(true);
 	});
 
 	test('leaves path style off for a plain AWS target', async () => {
-		expect(clientOf(new S3Uploader(s3Config('s3://bucket?region=eu-west-1'))).config.forcePathStyle).toBe(false);
+		const client = await clientOf(new S3Uploader(s3Config('s3://bucket?region=eu-west-1')));
+
+		expect(client.config.forcePathStyle).toBe(false);
+	});
+
+	test('does not build a client before the first upload', () => {
+		const uploader = new S3Uploader(s3Config('s3://bucket'));
+
+		expect((uploader as unknown as { client?: S3Client }).client).toBeUndefined();
 	});
 });
 
@@ -461,15 +474,21 @@ describe('deleteAfterUpload wiring', () => {
 		expect(new HttpUploader(httpConfig('https://collector/s?deleteAfterUpload=true')).deleteAfterUpload).toBe(true);
 	});
 
-	test('defaults to false when the URI is silent', () => {
-		expect(new S3Uploader(s3Config('s3://samples')).deleteAfterUpload).toBe(false);
-		expect(new HttpUploader(httpConfig('https://collector/s')).deleteAfterUpload).toBe(false);
+	test('defaults to true when the URI is silent', () => {
+		expect(new S3Uploader(s3Config('s3://samples')).deleteAfterUpload).toBe(true);
+		expect(new HttpUploader(httpConfig('https://collector/s')).deleteAfterUpload).toBe(true);
+	});
+
+	test('honours an explicit false', () => {
+		expect(new S3Uploader(s3Config('s3://samples?deleteAfterUpload=false')).deleteAfterUpload).toBe(false);
+		expect(new HttpUploader(httpConfig('https://collector/s?deleteAfterUpload=false')).deleteAfterUpload).toBe(false);
 	});
 
 	test('survives createUploader', () => {
 		expect(createUploader('s3://samples?deleteAfterUpload=true')?.deleteAfterUpload).toBe(true);
 		expect(createUploader('https://collector/s?deleteAfterUpload=true')?.deleteAfterUpload).toBe(true);
-		expect(createUploader('s3://samples')?.deleteAfterUpload).toBe(false);
+		expect(createUploader('s3://samples')?.deleteAfterUpload).toBe(true);
+		expect(createUploader('s3://samples?deleteAfterUpload=false')?.deleteAfterUpload).toBe(false);
 	});
 });
 

--- a/__tests__/unit-tests/uploader/Uploader.test.ts
+++ b/__tests__/unit-tests/uploader/Uploader.test.ts
@@ -1,0 +1,509 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { access, mkdtemp, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createUploader } from '../../../src/uploader/Uploader';
+import { S3Uploader } from '../../../src/uploader/S3Uploader';
+import { HttpUploader } from '../../../src/uploader/HttpUploader';
+import { HttpConfig, parseSamplesUploadUri, S3Config } from '../../../src/uploader/samplesUploadUri';
+
+const EMPTY_ENV: NodeJS.ProcessEnv = {};
+
+/** Narrow the parsed union to the member each uploader expects. */
+const s3Config = (raw: string, env: NodeJS.ProcessEnv = EMPTY_ENV): S3Config => {
+	const config = parseSamplesUploadUri(raw, env);
+
+	if (config.type !== 's3') throw new Error(`expected an s3 config, got "${config.type}"`);
+
+	return config;
+};
+
+const httpConfig = (raw: string, env: NodeJS.ProcessEnv = EMPTY_ENV): HttpConfig => {
+	const config = parseSamplesUploadUri(raw, env);
+
+	if (config.type !== 'http') throw new Error(`expected an http config, got "${config.type}"`);
+
+	return config;
+};
+
+const stubFetch = (...responses: Partial<Response>[]) => {
+	const impl = jest.fn();
+
+	for (const response of responses) {
+		impl.mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK', ...response } as Response);
+	}
+
+	return impl as unknown as jest.MockedFunction<typeof fetch>;
+};
+
+const stubClient = () => {
+	const send = jest.fn().mockResolvedValue({});
+
+	return { send, client: { send } as unknown as S3Client };
+};
+
+const lastCommand = (send: jest.Mock): PutObjectCommand => send.mock.calls[send.mock.calls.length - 1][0];
+
+describe('createUploader', () => {
+	test('returns undefined when no value is given', () => {
+		expect(createUploader(undefined)).toBeUndefined();
+	});
+
+	test('returns undefined for a valueless flag (minimist yields true)', () => {
+		expect(createUploader(true)).toBeUndefined();
+	});
+
+	test('returns undefined for a malformed value instead of throwing', () => {
+		expect(createUploader('s3://bucket?regoin=eu-north-1')).toBeUndefined();
+		expect(createUploader('my-bucket//http://minio:9000')).toBeUndefined();
+		expect(createUploader('s3://key:secret@bucket')).toBeUndefined();
+	});
+
+	test('builds an S3Uploader for a valid value', () => {
+		expect(createUploader('s3://bucket/prod?region=eu-north-1')).toBeInstanceOf(S3Uploader);
+	});
+
+	test('builds an HttpUploader for an http(s) value', () => {
+		expect(createUploader('http://collector/samples')).toBeInstanceOf(HttpUploader);
+		expect(createUploader('https://collector/samples')).toBeInstanceOf(HttpUploader);
+	});
+
+	test('accepts the bare bucket shorthand', () => {
+		expect(createUploader('my-bucket')).toBeInstanceOf(S3Uploader);
+	});
+});
+
+describe('S3Uploader', () => {
+	test('sends the body to the configured bucket under the given key', async () => {
+		const { send, client } = stubClient();
+		const uploader = new S3Uploader(s3Config('s3://samples'), client);
+
+		await uploader.upload({ key: 'room/call/summary.json', body: '{"a":1}', contentType: 'application/json' });
+
+		expect(send).toHaveBeenCalledTimes(1);
+		expect(lastCommand(send).input).toMatchObject({
+			Bucket: 'samples',
+			Key: 'room/call/summary.json',
+			Body: '{"a":1}',
+			ContentType: 'application/json',
+		});
+	});
+
+	test('prepends the key prefix from the URI', async () => {
+		const { send, client } = stubClient();
+		const uploader = new S3Uploader(s3Config('s3://samples/prod/eu'), client);
+
+		await uploader.upload({ key: 'room/call/summary.json', body: 'x', contentType: 'application/json' });
+
+		expect(lastCommand(send).input.Key).toBe('prod/eu/room/call/summary.json');
+	});
+
+	test('leaves the key untouched when the URI has no prefix', async () => {
+		const { send, client } = stubClient();
+		const uploader = new S3Uploader(s3Config('s3://samples'), client);
+
+		await uploader.upload({ key: 'room/call/c.jsonl', body: 'x', contentType: 'application/x-ndjson' });
+
+		expect(lastCommand(send).input.Key).toBe('room/call/c.jsonl');
+	});
+
+	test('propagates client failures to the caller', async () => {
+		const { send, client } = stubClient();
+
+		send.mockRejectedValueOnce(new Error('no such bucket'));
+
+		const uploader = new S3Uploader(s3Config('s3://samples'), client);
+
+		await expect(uploader.upload({ key: 'k', body: 'x', contentType: 'application/json' })).rejects.toThrow('no such bucket');
+	});
+});
+
+describe('S3Uploader - sourcePath', () => {
+	test('reads the file and uploads its contents under the prefixed key', async () => {
+		const { send, client } = stubClient();
+		const dir = await mkdtemp(join(tmpdir(), 'uploader-'));
+		const sourcePath = join(dir, 'client.jsonl');
+
+		await writeFile(sourcePath, '{"n":1}\n{"n":2}\n');
+
+		const uploader = new S3Uploader(s3Config('s3://samples/prod'), client);
+
+		await uploader.upload({ key: 'room/call/client.jsonl', sourcePath, contentType: 'application/x-ndjson' });
+
+		const { Bucket, Key, Body, ContentType } = lastCommand(send).input;
+
+		expect(Bucket).toBe('samples');
+		expect(Key).toBe('prod/room/call/client.jsonl');
+		expect(ContentType).toBe('application/x-ndjson');
+		expect(Body?.toString()).toBe('{"n":1}\n{"n":2}\n');
+	});
+
+	test('rejects when the file is missing', async () => {
+		const { client } = stubClient();
+		const uploader = new S3Uploader(s3Config('s3://samples'), client);
+
+		await expect(uploader.upload({ key: 'k', sourcePath: '/nope/missing.jsonl', contentType: 'application/x-ndjson' })).rejects.toThrow();
+	});
+
+	test('does not delete the source file after successful upload (cleanup is ObserverService-owned)', async () => {
+		const { client } = stubClient();
+		const dir = await mkdtemp(join(tmpdir(), 'uploader-delete-'));
+		const sourcePath = join(dir, 'client.jsonl');
+
+		await writeFile(sourcePath, '{"n":1}\n');
+
+		const uploader = new S3Uploader(s3Config('s3://samples?deleteAfterUpload=true'), client);
+
+		await uploader.upload({ key: 'room/call/client.jsonl', sourcePath, contentType: 'application/x-ndjson' });
+
+		await expect(access(sourcePath)).resolves.toBeUndefined();
+	});
+});
+
+describe('HttpUploader', () => {
+	test('POSTs the body to the base URL with the key appended', async () => {
+		const impl = stubFetch({});
+		const uploader = new HttpUploader(httpConfig('https://collector/samples'), impl);
+
+		await uploader.upload({ key: 'room/call/client.jsonl', body: '{"n":1}', contentType: 'application/x-ndjson' });
+
+		const [ url, init ] = impl.mock.calls[0];
+
+		expect(url).toBe('https://collector/samples/room/call/client.jsonl');
+		expect(init?.method).toBe('POST');
+		expect(init?.body).toBe('{"n":1}');
+		expect((init?.headers as Record<string, string>)['content-type']).toBe('application/x-ndjson');
+	});
+
+	test('sends a bearer token when one is configured', async () => {
+		const impl = stubFetch({});
+		const config = httpConfig('https://collector/s?credentialsEnv=COLLECTOR', { COLLECTOR_TOKEN: 't0ken' });
+
+		await new HttpUploader(config, impl).upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		expect((impl.mock.calls[0][1]?.headers as Record<string, string>).authorization).toBe('Bearer t0ken');
+	});
+
+	test('omits the authorization header when no token is configured', async () => {
+		const impl = stubFetch({});
+
+		await new HttpUploader(httpConfig('https://collector/s'), impl).upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		expect((impl.mock.calls[0][1]?.headers as Record<string, string>).authorization).toBeUndefined();
+	});
+
+	test('escapes each key segment', async () => {
+		const impl = stubFetch({});
+
+		await new HttpUploader(httpConfig('https://collector/s'), impl).upload({ key: 'room a/call#1/c.jsonl', body: 'x', contentType: 'application/json' });
+
+		expect(impl.mock.calls[0][0]).toBe('https://collector/s/room%20a/call%231/c.jsonl');
+	});
+
+	test('retries a 5xx and resolves once it succeeds', async () => {
+		const impl = stubFetch({ ok: false, status: 503, statusText: 'Service Unavailable' }, {});
+
+		await new HttpUploader(httpConfig('https://collector/s?maxAttempts=3'), impl).upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		expect(impl).toHaveBeenCalledTimes(2);
+	});
+
+	test('does not retry a 4xx', async () => {
+		const impl = stubFetch({ ok: false, status: 400, statusText: 'Bad Request' });
+
+		await expect(new HttpUploader(httpConfig('https://collector/s?maxAttempts=3'), impl).upload({ key: 'k', body: 'x', contentType: 'application/json' }))
+			.rejects.toThrow(/400 Bad Request/);
+		expect(impl).toHaveBeenCalledTimes(1);
+	});
+
+	test('gives up after maxAttempts', async () => {
+		const impl = stubFetch({ ok: false, status: 500, statusText: 'Server Error' }, { ok: false, status: 500, statusText: 'Server Error' });
+
+		await expect(new HttpUploader(httpConfig('https://collector/s?maxAttempts=2'), impl).upload({ key: 'k', body: 'x', contentType: 'application/json' }))
+			.rejects.toThrow(/500 Server Error/);
+		expect(impl).toHaveBeenCalledTimes(2);
+	});
+
+	test('retries a network failure', async () => {
+		const impl = jest.fn()
+			.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+			.mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' } as Response) as unknown as jest.MockedFunction<typeof fetch>;
+
+		await new HttpUploader(httpConfig('https://collector/s?maxAttempts=2'), impl).upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		expect(impl).toHaveBeenCalledTimes(2);
+	});
+
+	test('reads the file and POSTs its contents', async () => {
+		const impl = stubFetch({});
+		const dir = await mkdtemp(join(tmpdir(), 'http-uploader-'));
+		const sourcePath = join(dir, 'client.jsonl');
+
+		await writeFile(sourcePath, '{"n":1}\n');
+
+		await new HttpUploader(httpConfig('https://collector/s'), impl).upload({ key: 'room/c.jsonl', sourcePath, contentType: 'application/x-ndjson' });
+
+		expect(impl.mock.calls[0][0]).toBe('https://collector/s/room/c.jsonl');
+		expect(impl.mock.calls[0][1]?.body?.toString()).toBe('{"n":1}\n');
+	});
+
+	test('does not delete the source file after successful upload (cleanup is ObserverService-owned)', async () => {
+		const impl = stubFetch({});
+		const dir = await mkdtemp(join(tmpdir(), 'http-uploader-delete-'));
+		const sourcePath = join(dir, 'client.jsonl');
+
+		await writeFile(sourcePath, '{"n":1}\n');
+
+		const uploader = new HttpUploader(httpConfig('https://collector/s?deleteAfterUpload=true'), impl);
+
+		await uploader.upload({ key: 'room/call/client.jsonl', sourcePath, contentType: 'application/x-ndjson' });
+
+		await expect(access(sourcePath)).resolves.toBeUndefined();
+	});
+});
+
+describe('Uploader contract', () => {
+	test('rejects when neither body nor sourcePath is given', async () => {
+		const { client } = stubClient();
+		const impl = stubFetch({});
+
+		await expect(new S3Uploader(s3Config('s3://samples'), client)
+			.upload({ key: 'k', contentType: 'application/json' })).rejects.toThrow(/neither body nor sourcePath/);
+		await expect(new HttpUploader(httpConfig('https://collector/s'), impl)
+			.upload({ key: 'k', contentType: 'application/json' })).rejects.toThrow(/neither body nor sourcePath/);
+	});
+
+	test('sourcePath takes precedence over body', async () => {
+		const { send, client } = stubClient();
+		const dir = await mkdtemp(join(tmpdir(), 'precedence-'));
+		const sourcePath = join(dir, 'from-disk.jsonl');
+
+		await writeFile(sourcePath, 'from-disk');
+
+		await new S3Uploader(s3Config('s3://samples'), client)
+			.upload({ key: 'k', body: 'from-memory', sourcePath, contentType: 'application/json' });
+
+		expect(lastCommand(send).input.Body?.toString()).toBe('from-disk');
+	});
+
+	test('S3Uploader counts completed and failed uploads', async () => {
+		const { send, client } = stubClient();
+		const uploader = new S3Uploader(s3Config('s3://samples'), client);
+
+		expect(uploader.stats).toEqual({ ongoingUploads: 0, completedUploads: 0, failedUploads: 0 });
+
+		await uploader.upload({ key: 'a', body: 'x', contentType: 'application/json' });
+
+		expect(uploader.stats).toEqual({ ongoingUploads: 0, completedUploads: 1, failedUploads: 0 });
+
+		send.mockRejectedValueOnce(new Error('boom'));
+		await expect(uploader.upload({ key: 'b', body: 'x', contentType: 'application/json' })).rejects.toThrow('boom');
+
+		expect(uploader.stats).toEqual({ ongoingUploads: 0, completedUploads: 1, failedUploads: 1 });
+	});
+
+	test('HttpUploader counts a retried upload once', async () => {
+		const impl = stubFetch({ ok: false, status: 503, statusText: 'Service Unavailable' }, {});
+		const uploader = new HttpUploader(httpConfig('https://collector/s?maxAttempts=3'), impl);
+
+		await uploader.upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		expect(impl).toHaveBeenCalledTimes(2);
+		expect(uploader.stats).toEqual({ ongoingUploads: 0, completedUploads: 1, failedUploads: 0 });
+	});
+
+	test('ongoingUploads tracks work in flight', async () => {
+		let release: () => void = () => undefined;
+		const gate = new Promise<void>((resolve) => (release = resolve));
+		const impl = jest.fn().mockImplementation(async () => {
+			await gate;
+
+			return { ok: true, status: 200, statusText: 'OK' } as Response;
+		}) as unknown as jest.MockedFunction<typeof fetch>;
+		const uploader = new HttpUploader(httpConfig('https://collector/s'), impl);
+		const inFlight = uploader.upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		await Promise.resolve();
+		expect(uploader.stats.ongoingUploads).toBe(1);
+
+		release();
+		await inFlight;
+
+		expect(uploader.stats).toEqual({ ongoingUploads: 0, completedUploads: 1, failedUploads: 0 });
+	});
+});
+
+describe('createUploader - credential resolution failures', () => {
+	test('returns undefined when the s3 credential variables are missing', () => {
+		expect(createUploader('s3://bucket?credentialsEnv=NOPE')).toBeUndefined();
+	});
+
+	test('returns undefined when the http token variable is missing', () => {
+		expect(createUploader('https://collector/s?credentialsEnv=NOPE')).toBeUndefined();
+	});
+});
+
+describe('S3Uploader - client configuration', () => {
+	const clientOf = (uploader: S3Uploader): S3Client =>
+		(uploader as unknown as { client: S3Client }).client;
+
+	test('applies region and path style from the URI', async () => {
+		const uploader = new S3Uploader(s3Config('s3://bucket?endpoint=http://minio:9000&region=eu-north-1'));
+		const { config } = clientOf(uploader);
+
+		expect(await config.region()).toBe('eu-north-1');
+		expect(config.forcePathStyle).toBe(true);
+	});
+
+	test('leaves path style off for a plain AWS target', async () => {
+		expect(clientOf(new S3Uploader(s3Config('s3://bucket?region=eu-west-1'))).config.forcePathStyle).toBe(false);
+	});
+});
+
+describe('S3Uploader - payload types', () => {
+	test('passes a Buffer body through unchanged', async () => {
+		const { send, client } = stubClient();
+		const body = Buffer.from('binary-ish');
+
+		await new S3Uploader(s3Config('s3://samples'), client)
+			.upload({ key: 'k', body, contentType: 'application/octet-stream' });
+
+		expect(lastCommand(send).input.Body).toBe(body);
+	});
+
+	test('passes a Uint8Array body through unchanged', async () => {
+		const { send, client } = stubClient();
+		const body = new Uint8Array([ 1, 2, 3 ]);
+
+		await new S3Uploader(s3Config('s3://samples'), client)
+			.upload({ key: 'k', body, contentType: 'application/octet-stream' });
+
+		expect(lastCommand(send).input.Body).toBe(body);
+	});
+});
+
+describe('HttpUploader - retry policy', () => {
+	test('retries a 429', async () => {
+		const impl = stubFetch({ ok: false, status: 429, statusText: 'Too Many Requests' }, {});
+
+		await new HttpUploader(httpConfig('https://collector/s?maxAttempts=2'), impl)
+			.upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		expect(impl).toHaveBeenCalledTimes(2);
+	});
+
+	test('defaults to three attempts when maxAttempts is absent', async () => {
+		const failure = { ok: false, status: 500, statusText: 'Server Error' };
+		const impl = stubFetch(failure, failure, failure);
+
+		await expect(new HttpUploader(httpConfig('https://collector/s'), impl)
+			.upload({ key: 'k', body: 'x', contentType: 'application/json' })).rejects.toThrow(/500/);
+
+		expect(impl).toHaveBeenCalledTimes(3);
+	});
+
+	test('counts one failed upload after exhausting attempts', async () => {
+		const failure = { ok: false, status: 500, statusText: 'Server Error' };
+		const impl = stubFetch(failure, failure);
+		const uploader = new HttpUploader(httpConfig('https://collector/s?maxAttempts=2'), impl);
+
+		await expect(uploader.upload({ key: 'k', body: 'x', contentType: 'application/json' })).rejects.toThrow();
+
+		expect(uploader.stats).toEqual({ ongoingUploads: 0, completedUploads: 0, failedUploads: 1 });
+	});
+
+	test('backs off between attempts rather than hammering', async () => {
+		const failure = { ok: false, status: 500, statusText: 'Server Error' };
+		const impl = stubFetch(failure, failure, failure);
+		const started = Date.now();
+
+		await expect(new HttpUploader(httpConfig('https://collector/s?maxAttempts=3'), impl)
+			.upload({ key: 'k', body: 'x', contentType: 'application/json' })).rejects.toThrow();
+
+		// 100ms before the second attempt, 200ms before the third.
+		expect(Date.now() - started).toBeGreaterThanOrEqual(250);
+	});
+
+	test('does not sleep before failing on a non-retriable status', async () => {
+		const impl = stubFetch({ ok: false, status: 403, statusText: 'Forbidden' });
+		const started = Date.now();
+
+		await expect(new HttpUploader(httpConfig('https://collector/s?maxAttempts=3'), impl)
+			.upload({ key: 'k', body: 'x', contentType: 'application/json' })).rejects.toThrow(/403/);
+
+		expect(Date.now() - started).toBeLessThan(100);
+	});
+});
+
+describe('HttpUploader - request shape', () => {
+	test('passes an abort signal so a hung collector cannot stall uploads', async () => {
+		const impl = stubFetch({});
+
+		await new HttpUploader(httpConfig('https://collector/s'), impl)
+			.upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		expect(impl.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	test('drops empty key segments instead of producing double slashes', async () => {
+		const impl = stubFetch({});
+
+		await new HttpUploader(httpConfig('https://collector/s'), impl)
+			.upload({ key: '/room//call/c.jsonl', body: 'x', contentType: 'application/json' });
+
+		expect(impl.mock.calls[0][0]).toBe('https://collector/s/room/call/c.jsonl');
+	});
+});
+
+describe('deleteAfterUpload wiring', () => {
+	test('reaches the uploader from the URI', () => {
+		expect(new S3Uploader(s3Config('s3://samples?deleteAfterUpload=true')).deleteAfterUpload).toBe(true);
+		expect(new HttpUploader(httpConfig('https://collector/s?deleteAfterUpload=true')).deleteAfterUpload).toBe(true);
+	});
+
+	test('defaults to false when the URI is silent', () => {
+		expect(new S3Uploader(s3Config('s3://samples')).deleteAfterUpload).toBe(false);
+		expect(new HttpUploader(httpConfig('https://collector/s')).deleteAfterUpload).toBe(false);
+	});
+
+	test('survives createUploader', () => {
+		expect(createUploader('s3://samples?deleteAfterUpload=true')?.deleteAfterUpload).toBe(true);
+		expect(createUploader('https://collector/s?deleteAfterUpload=true')?.deleteAfterUpload).toBe(true);
+		expect(createUploader('s3://samples')?.deleteAfterUpload).toBe(false);
+	});
+});
+
+describe('Uploader stats - isolation and concurrency', () => {
+	test('each uploader keeps its own counters', async () => {
+		const first = new S3Uploader(s3Config('s3://samples'), stubClient().client);
+		const second = new S3Uploader(s3Config('s3://samples'), stubClient().client);
+
+		await first.upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		expect(first.stats.completedUploads).toBe(1);
+		expect(second.stats.completedUploads).toBe(0);
+	});
+
+	test('ongoingUploads counts concurrent uploads', async () => {
+		let release: () => void = () => undefined;
+		const gate = new Promise<void>((resolve) => (release = resolve));
+		const send = jest.fn().mockImplementation(async () => {
+			await gate;
+
+			return {};
+		});
+		const uploader = new S3Uploader(s3Config('s3://samples'), { send } as unknown as S3Client);
+		const inFlight = [
+			uploader.upload({ key: 'a', body: 'x', contentType: 'application/json' }),
+			uploader.upload({ key: 'b', body: 'x', contentType: 'application/json' }),
+		];
+
+		await Promise.resolve();
+		expect(uploader.stats.ongoingUploads).toBe(2);
+
+		release();
+		await Promise.all(inFlight);
+
+		expect(uploader.stats).toEqual({ ongoingUploads: 0, completedUploads: 2, failedUploads: 0 });
+	});
+});

--- a/__tests__/unit-tests/uploader/Uploader.test.ts
+++ b/__tests__/unit-tests/uploader/Uploader.test.ts
@@ -468,6 +468,68 @@ describe('HttpUploader - request shape', () => {
 	});
 });
 
+/*
+ * Nothing here reads a response body, and undici holds the connection until one
+ * is read or cancelled — so an unread body costs connection reuse and, under
+ * retry, leaks. Every attempt has to release its own.
+ */
+describe('HttpUploader - response bodies', () => {
+	const bodyStub = () => {
+		const cancel = jest.fn().mockResolvedValue(undefined);
+
+		return { cancel, body: { cancel } as unknown as NonNullable<Response['body']> };
+	};
+
+	test('cancels the body of a successful response', async () => {
+		const { cancel, body } = bodyStub();
+		const impl = stubFetch({ body });
+
+		await new HttpUploader(httpConfig('https://collector/s'), impl)
+			.upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		expect(cancel).toHaveBeenCalledTimes(1);
+	});
+
+	test('cancels the body of every attempt, not just the last', async () => {
+		const first = bodyStub();
+		const second = bodyStub();
+		const impl = stubFetch(
+			{ ok: false, status: 503, statusText: 'Service Unavailable', body: first.body },
+			{ body: second.body },
+		);
+
+		await new HttpUploader(httpConfig('https://collector/s?maxAttempts=2'), impl)
+			.upload({ key: 'k', body: 'x', contentType: 'application/json' });
+
+		expect(first.cancel).toHaveBeenCalledTimes(1);
+		expect(second.cancel).toHaveBeenCalledTimes(1);
+	});
+
+	test('cancels the body before giving up on a non-retriable status', async () => {
+		const { cancel, body } = bodyStub();
+		const impl = stubFetch({ ok: false, status: 400, statusText: 'Bad Request', body });
+
+		await expect(new HttpUploader(httpConfig('https://collector/s'), impl)
+			.upload({ key: 'k', body: 'x', contentType: 'application/json' })).rejects.toThrow(/400/);
+
+		expect(cancel).toHaveBeenCalledTimes(1);
+	});
+
+	test('does not fail the upload when the body refuses to cancel', async () => {
+		const body = { cancel: jest.fn().mockRejectedValue(new Error('locked')) } as unknown as NonNullable<Response['body']>;
+
+		await expect(new HttpUploader(httpConfig('https://collector/s'), stubFetch({ body }))
+			.upload({ key: 'k', body: 'x', contentType: 'application/json' })).resolves.toBeUndefined();
+	});
+
+	test('tolerates a response with no body at all', async () => {
+		const impl = stubFetch({ body: null });
+
+		await expect(new HttpUploader(httpConfig('https://collector/s'), impl)
+			.upload({ key: 'k', body: 'x', contentType: 'application/json' })).resolves.toBeUndefined();
+	});
+});
+
 describe('deleteAfterUpload wiring', () => {
 	test('reaches the uploader from the URI', () => {
 		expect(new S3Uploader(s3Config('s3://samples?deleteAfterUpload=true')).deleteAfterUpload).toBe(true);

--- a/__tests__/unit-tests/uploader/samplesUploadUri.test.ts
+++ b/__tests__/unit-tests/uploader/samplesUploadUri.test.ts
@@ -263,7 +263,7 @@ describe('describeSamplesUploadConfig', () => {
 			type: 'http',
 			url: 'https://collector/samples',
 			credentials: 'env:COLLECTOR_TOKEN',
-			deleteAfterUpload: false,
+			deleteAfterUpload: true,
 		});
 	});
 
@@ -276,7 +276,7 @@ describe('describeSamplesUploadConfig', () => {
 			region: '<sdk default>',
 			forcePathStyle: false,
 			credentials: 'sdk default chain',
-			deleteAfterUpload: false,
+			deleteAfterUpload: true,
 		});
 	});
 });

--- a/__tests__/unit-tests/uploader/samplesUploadUri.test.ts
+++ b/__tests__/unit-tests/uploader/samplesUploadUri.test.ts
@@ -1,0 +1,282 @@
+import { describeSamplesUploadConfig, HttpConfig, parseSamplesUploadUri, S3Config, SamplesUploadUriError } from '../../../src/uploader/samplesUploadUri';
+
+const EMPTY_ENV: NodeJS.ProcessEnv = {};
+
+/** Narrow to the s3 member so the S3-specific assertions below stay readable. */
+const parseS3 = (raw: string, env: NodeJS.ProcessEnv = EMPTY_ENV): S3Config => {
+	const config = parseSamplesUploadUri(raw, env);
+
+	if (config.type !== 's3') throw new Error(`expected an s3 config, got "${config.type}"`);
+
+	return config;
+};
+
+describe('parseSamplesUploadUri - destination', () => {
+	test('parses a bare bucket shorthand', () => {
+		expect(parseS3('my-bucket')).toEqual({
+			type: 's3',
+			bucket: 'my-bucket',
+			forcePathStyle: false,
+		});
+	});
+
+	test('discriminates the target kind by scheme', () => {
+		expect(parseSamplesUploadUri('s3://bucket', EMPTY_ENV).type).toBe('s3');
+		expect(parseSamplesUploadUri('my-bucket', EMPTY_ENV).type).toBe('s3');
+		expect(parseSamplesUploadUri('http://collector/samples', EMPTY_ENV).type).toBe('http');
+		expect(parseSamplesUploadUri('https://collector/samples', EMPTY_ENV).type).toBe('http');
+	});
+
+	test('parses bucket and key prefix', () => {
+		const config = parseS3('s3://edumeet-samples/prod/eu');
+
+		expect(config.bucket).toBe('edumeet-samples');
+		expect(config.keyPrefix).toBe('prod/eu');
+	});
+
+	test('normalises surrounding slashes in the key prefix', () => {
+		expect(parseS3('s3://bucket///prod//').keyPrefix).toBe('prod');
+	});
+
+	test('leaves the key prefix undefined when absent', () => {
+		expect(parseS3('s3://bucket').keyPrefix).toBeUndefined();
+		expect(parseS3('s3://bucket/').keyPrefix).toBeUndefined();
+	});
+
+	test('decodes percent-encoded key prefixes', () => {
+		expect(parseS3('s3://bucket/pro%20d').keyPrefix).toBe('pro d');
+	});
+});
+
+describe('parseSamplesUploadUri - endpoint and path style', () => {
+	test('enables path style by default when an endpoint is given', () => {
+		const config = parseS3('s3://bucket?endpoint=http://minio.ns.svc:9000');
+
+		expect(config.endpoint).toBe('http://minio.ns.svc:9000');
+		expect(config.forcePathStyle).toBe(true);
+	});
+
+	test('leaves path style off for AWS', () => {
+		expect(parseS3('s3://bucket').forcePathStyle).toBe(false);
+	});
+
+	test('allows path style to be overridden explicitly', () => {
+		expect(parseS3('s3://bucket?endpoint=https://s3.example.com&pathStyle=false').forcePathStyle).toBe(false);
+		expect(parseS3('s3://bucket?pathStyle=true').forcePathStyle).toBe(true);
+	});
+
+	test('rejects a non-http endpoint', () => {
+		expect(() => parseSamplesUploadUri('s3://bucket?endpoint=ftp://example.com', EMPTY_ENV)).toThrow(SamplesUploadUriError);
+	});
+
+	test('rejects a non-boolean pathStyle', () => {
+		expect(() => parseSamplesUploadUri('s3://bucket?pathStyle=maybe', EMPTY_ENV)).toThrow(/must be a boolean/);
+	});
+});
+
+describe('parseSamplesUploadUri - region', () => {
+	test('prefers the explicit region parameter', () => {
+		expect(parseS3('s3://bucket?region=eu-north-1', { AWS_REGION: 'us-east-2' }).region).toBe('eu-north-1');
+	});
+
+	test('falls back to AWS_REGION, then AWS_DEFAULT_REGION', () => {
+		expect(parseS3('s3://bucket', { AWS_REGION: 'eu-west-1' }).region).toBe('eu-west-1');
+		expect(parseS3('s3://bucket', { AWS_DEFAULT_REGION: 'eu-west-2' }).region).toBe('eu-west-2');
+	});
+
+	test('leaves the region to the SDK for AWS, but defaults it for a custom endpoint', () => {
+		expect(parseS3('s3://bucket').region).toBeUndefined();
+		expect(parseS3('s3://bucket?endpoint=http://minio:9000').region).toBe('us-east-1');
+	});
+});
+
+describe('parseSamplesUploadUri - credentials', () => {
+	test('resolves static credentials from a named env prefix', () => {
+		const config = parseS3('s3://bucket?credentialsEnv=minio', {
+			MINIO_ACCESS_KEY_ID: 'key',
+			MINIO_SECRET_ACCESS_KEY: 'secret',
+		});
+
+		expect(config.credentialsEnv).toBe('minio');
+		expect(config.credentials).toEqual({ accessKeyId: 'key', secretAccessKey: 'secret' });
+	});
+
+	test('picks up an optional session token', () => {
+		const config = parseS3('s3://bucket?credentialsEnv=MINIO', {
+			MINIO_ACCESS_KEY_ID: 'key',
+			MINIO_SECRET_ACCESS_KEY: 'secret',
+			MINIO_SESSION_TOKEN: 'token',
+		});
+
+		expect(config.credentials?.sessionToken).toBe('token');
+	});
+
+	test('names the missing variables when they are not set', () => {
+		expect(() => parseSamplesUploadUri('s3://bucket?credentialsEnv=MINIO', EMPTY_ENV))
+			.toThrow(/MINIO_ACCESS_KEY_ID and MINIO_SECRET_ACCESS_KEY/);
+	});
+
+	test('defers to the SDK chain when credentialsEnv is absent', () => {
+		expect(parseS3('s3://bucket').credentials).toBeUndefined();
+	});
+
+	test('refuses credentials embedded in the URI', () => {
+		expect(() => parseSamplesUploadUri('s3://key:secret@bucket', EMPTY_ENV)).toThrow(/must not be embedded/);
+	});
+});
+
+describe('parseSamplesUploadUri - rejections', () => {
+	test('rejects an empty value', () => {
+		expect(() => parseSamplesUploadUri('   ', EMPTY_ENV)).toThrow(/must not be empty/);
+	});
+
+	test('rejects the legacy bucket//endpoint form with a migration hint', () => {
+		expect(() => parseSamplesUploadUri('my-bucket//http://minio.ns.svc:9000', EMPTY_ENV))
+			.toThrow('--samplesUploadUri: the "bucket//endpoint" form is no longer supported. Use "s3://my-bucket?endpoint=http://minio.ns.svc:9000" instead.');
+	});
+
+	test('rejects unsupported schemes by name', () => {
+		expect(() => parseSamplesUploadUri('ftp://host/dir', EMPTY_ENV)).toThrow(/unsupported scheme "ftp:\/\/"/);
+		expect(() => parseSamplesUploadUri('gs://bucket', EMPTY_ENV)).toThrow(/unsupported scheme "gs:\/\/"/);
+	});
+
+	test('rejects unknown parameters', () => {
+		expect(() => parseSamplesUploadUri('s3://bucket?regoin=eu-north-1', EMPTY_ENV)).toThrow(/unknown parameter\(s\) regoin/);
+	});
+
+	test('rejects invalid bucket names', () => {
+		expect(() => parseSamplesUploadUri('s3://Bucket-Upper', EMPTY_ENV)).toThrow(/not a valid bucket name/);
+		expect(() => parseSamplesUploadUri('s3://ab', EMPTY_ENV)).toThrow(/not a valid bucket name/);
+	});
+
+	test('rejects a non-positive maxAttempts', () => {
+		expect(() => parseSamplesUploadUri('s3://bucket?maxAttempts=0', EMPTY_ENV)).toThrow(/integer >= 1/);
+		expect(() => parseSamplesUploadUri('s3://bucket?maxAttempts=lots', EMPTY_ENV)).toThrow(/integer >= 1/);
+	});
+
+	test('accepts a valid maxAttempts', () => {
+		expect(parseS3('s3://bucket?maxAttempts=5').maxAttempts).toBe(5);
+	});
+});
+
+describe('parseSamplesUploadUri - deleteAfterUpload', () => {
+	test('is undefined unless asked for, so the uploader can pick the default', () => {
+		expect(parseS3('s3://bucket').deleteAfterUpload).toBeUndefined();
+		expect(parseSamplesUploadUri('https://collector/s', EMPTY_ENV).deleteAfterUpload).toBeUndefined();
+	});
+
+	test('parses on both schemes', () => {
+		expect(parseS3('s3://bucket?deleteAfterUpload=true').deleteAfterUpload).toBe(true);
+		expect(parseSamplesUploadUri('https://collector/s?deleteAfterUpload=true', EMPTY_ENV).deleteAfterUpload).toBe(true);
+	});
+
+	test('can be turned off explicitly', () => {
+		expect(parseS3('s3://bucket?deleteAfterUpload=false').deleteAfterUpload).toBe(false);
+		expect(parseSamplesUploadUri('https://collector/s?deleteAfterUpload=off', EMPTY_ENV).deleteAfterUpload).toBe(false);
+	});
+
+	test('rejects a non-boolean value', () => {
+		expect(() => parseSamplesUploadUri('s3://bucket?deleteAfterUpload=sometimes', EMPTY_ENV))
+			.toThrow(/"deleteAfterUpload" must be a boolean/);
+	});
+
+	test('is reported in the log-safe description', () => {
+		expect(describeSamplesUploadConfig(parseS3('s3://bucket?deleteAfterUpload=true')).deleteAfterUpload).toBe(true);
+		expect(describeSamplesUploadConfig(parseSamplesUploadUri('https://collector/s?deleteAfterUpload=true', EMPTY_ENV)).deleteAfterUpload).toBe(true);
+	});
+});
+
+describe('parseSamplesUploadUri - http', () => {
+	const parseHttp = (raw: string, env: NodeJS.ProcessEnv = EMPTY_ENV): HttpConfig => {
+		const config = parseSamplesUploadUri(raw, env);
+
+		if (config.type !== 'http') throw new Error(`expected an http config, got "${config.type}"`);
+
+		return config;
+	};
+
+	test('keeps the base URL and strips the query string', () => {
+		expect(parseHttp('http://collector.ns.svc:8080/samples?credentialsEnv=COLLECTOR', { COLLECTOR_TOKEN: 't0ken' }).url)
+			.toBe('http://collector.ns.svc:8080/samples');
+	});
+
+	test('drops a trailing slash so keys append cleanly', () => {
+		expect(parseHttp('https://collector/samples/').url).toBe('https://collector/samples');
+	});
+
+	test('preserves the scheme', () => {
+		expect(parseHttp('https://collector/s').url).toBe('https://collector/s');
+		expect(parseHttp('http://collector/s').url).toBe('http://collector/s');
+	});
+
+	test('resolves a bearer token from the named env prefix', () => {
+		const config = parseHttp('https://collector/samples?credentialsEnv=collector', { COLLECTOR_TOKEN: 't0ken' });
+
+		expect(config.credentialsEnv).toBe('collector');
+		expect(config.token).toBe('t0ken');
+	});
+
+	test('names the missing token variable', () => {
+		expect(() => parseSamplesUploadUri('https://collector/s?credentialsEnv=COLLECTOR', EMPTY_ENV))
+			.toThrow(/requires COLLECTOR_TOKEN to be set/);
+	});
+
+	test('leaves the token undefined when credentialsEnv is absent', () => {
+		expect(parseHttp('https://collector/s').token).toBeUndefined();
+	});
+
+	test('rejects s3-only parameters', () => {
+		expect(() => parseSamplesUploadUri('https://collector/s?region=eu-north-1', EMPTY_ENV))
+			.toThrow(/unknown parameter\(s\) region\. Supported: credentialsEnv, maxAttempts/);
+	});
+
+	test('refuses credentials embedded in the URI', () => {
+		expect(() => parseSamplesUploadUri('https://user:pass@collector/s', EMPTY_ENV)).toThrow(/must not be embedded/);
+	});
+
+	test('accepts maxAttempts', () => {
+		expect(parseHttp('https://collector/s?maxAttempts=5').maxAttempts).toBe(5);
+	});
+});
+
+describe('describeSamplesUploadConfig', () => {
+	test('renders a reference instead of the resolved secret', () => {
+		const config = parseSamplesUploadUri('s3://bucket/prod?endpoint=http://minio:9000&credentialsEnv=minio', {
+			MINIO_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+			MINIO_SECRET_ACCESS_KEY: 'super-secret',
+		});
+		const described = JSON.stringify(describeSamplesUploadConfig(config));
+
+		expect(described).not.toContain('super-secret');
+		expect(described).not.toContain('AKIAEXAMPLE');
+		expect(describeSamplesUploadConfig(config).credentials).toBe('env:MINIO_*');
+	});
+
+	test('renders an http target without leaking the token', () => {
+		const config = parseSamplesUploadUri('https://collector/samples?credentialsEnv=collector', {
+			COLLECTOR_TOKEN: 'super-secret',
+		});
+		const described = describeSamplesUploadConfig(config);
+
+		expect(JSON.stringify(described)).not.toContain('super-secret');
+		expect(described).toEqual({
+			type: 'http',
+			url: 'https://collector/samples',
+			credentials: 'env:COLLECTOR_TOKEN',
+			deleteAfterUpload: false,
+		});
+	});
+
+	test('reports the default chain when no credentials are configured', () => {
+		expect(describeSamplesUploadConfig(parseSamplesUploadUri('s3://bucket', EMPTY_ENV))).toEqual({
+			type: 's3',
+			bucket: 'bucket',
+			keyPrefix: '<none>',
+			endpoint: 'AWS',
+			region: '<sdk default>',
+			forcePathStyle: false,
+			credentials: 'sdk default chain',
+			deleteAfterUpload: false,
+		});
+	});
+});

--- a/__tests__/unit-tests/uploader/samplesUploadUri.test.ts
+++ b/__tests__/unit-tests/uploader/samplesUploadUri.test.ts
@@ -239,6 +239,28 @@ describe('parseSamplesUploadUri - http', () => {
 	});
 });
 
+describe('parseSamplesUploadUri - fragments', () => {
+	// A fragment never leaves the process, so a base that carries one would send
+	// every upload to the path in front of it instead of where it appears to point.
+	test('rejects a fragment on an http(s) target', () => {
+		expect(() => parseSamplesUploadUri('https://collector/samples#frag', EMPTY_ENV)).toThrow(SamplesUploadUriError);
+		expect(() => parseSamplesUploadUri('https://collector/samples#frag', EMPTY_ENV)).toThrow(/fragment/);
+	});
+
+	test('rejects a fragment that follows the query string', () => {
+		expect(() => parseSamplesUploadUri('https://collector/samples?maxAttempts=2#frag', EMPTY_ENV)).toThrow(/fragment/);
+	});
+
+	test('rejects a fragment on an s3 target too, rather than dropping it silently', () => {
+		expect(() => parseSamplesUploadUri('s3://bucket/prod#frag', EMPTY_ENV)).toThrow(/fragment/);
+	});
+
+	test('leaves fragment-free values alone', () => {
+		expect(parseHttp('https://collector/samples').url).toBe('https://collector/samples');
+		expect(parseS3('s3://bucket/prod').keyPrefix).toBe('prod');
+	});
+});
+
 describe('describeSamplesUploadConfig', () => {
 	test('renders a reference instead of the resolved secret', () => {
 		const config = parseSamplesUploadUri('s3://bucket/prod?endpoint=http://minio:9000&credentialsEnv=minio', {

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	modulePathIgnorePatterns: [ '<rootDir>/dist' ],
 	transform: {
 		'^.+\\.[t]s$': [
-			'ts-jest', { tsconfig: 'src/tsconfig.json' }
+			'ts-jest', { tsconfig: 'tsconfig.jest.json' }
 		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.1102.0",
-		"@observertc/observer-js": "1.0.0-beta.12",
+		"@observertc/observer-js": "1.0.0-beta.13",
 		"debug": "^4.4.3",
 		"edumeet-common": "github:edumeet/edumeet-common#0.7.0",
 		"mediasoup": "^3.23.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
 		"typescript": "^5.9.3"
 	},
 	"dependencies": {
+		"@aws-sdk/client-s3": "^3.1102.0",
+		"@observertc/observer-js": "1.0.0-beta.12",
 		"debug": "^4.4.3",
 		"edumeet-common": "github:edumeet/edumeet-common#0.7.0",
 		"mediasoup": "^3.23.2",

--- a/src/MediaService.ts
+++ b/src/MediaService.ts
@@ -4,7 +4,7 @@ import * as mediasoup from 'mediasoup';
 // import { MediasoupMonitor, createMediasoupMonitor, MediasoupMonitorConfig, TransportTypeFunction, MediasoupTransportType } from '@observertc/sfu-monitor-js';
 import { List, Logger, skipIfClosed } from 'edumeet-common';
 
-import { ActiveSpeakerObserver, AudioLevelObserver, Consumer, DataConsumer, DataProducer, PipeTransport, Producer, Router, RtpHeaderExtension, Transport, TransportListenInfo, WebRtcServer, WebRtcTransport, Worker, WorkerLogLevel, WorkerLogTag } from 'mediasoup/types';
+import { ActiveSpeakerObserver, AudioLevelObserver, Consumer, DataConsumer, DataProducer, DirectTransport, PipeTransport, Producer, Router, RtpHeaderExtension, Transport, TransportListenInfo, WebRtcServer, WebRtcTransport, Worker, WorkerLogLevel, WorkerLogTag } from 'mediasoup/types';
 
 const logger = new Logger('MediaService');
 
@@ -40,6 +40,13 @@ export interface RouterData {
 	pipeDataConsumers: Map<string, DataConsumer>;
 	activeSpeakerObservers: Map<string, ActiveSpeakerObserver>;
 	audioLevelObservers: Map<string, AudioLevelObserver>;
+
+	/**
+	 * Carries observertc sample data channels to the ObserverService. Created
+	 * lazily on the first `observertc-samples` DataProducer, so routers on nodes
+	 * without sample collection configured never pay for one.
+	 */
+	directTransport?: DirectTransport;
 	remoteClose?: boolean;
 }
 

--- a/src/ObserverService.ts
+++ b/src/ObserverService.ts
@@ -1,5 +1,5 @@
 import { Logger } from 'edumeet-common';
-import { unlink } from 'fs/promises';
+import { stat, unlink } from 'fs/promises';
 import { DataConsumer } from 'mediasoup/types';
 import * as mediasoup from 'mediasoup';
 import {
@@ -92,6 +92,19 @@ export class ObserverService extends Observer {
 
 		logger.debug('constructor()');
 
+		if (options.samplesStorePath && options.uploader) {
+			logger.info(
+				'observertc sample collection enabled [storePath: %s, deleteAfterUpload: %s]',
+				options.samplesStorePath,
+				String(options.uploader.deleteAfterUpload)
+			);
+		} else if (options.samplesStorePath) {
+			logger.info(
+				'observertc sample collection enabled, uploads disabled [storePath: %s]',
+				options.samplesStorePath
+			);
+		}
+
 		this.setupObserverEvents();
 		this.config.createCallAppData = this.createObservedCallAppData.bind(this);
 	}
@@ -156,8 +169,14 @@ export class ObserverService extends Observer {
 		// about routers, so they can be attached to the calls that use them.
 		mediasoup.observer.on('newworker', this.handleNewMediasoupWorker);
 
-		if (this.options.uploader) {
+		// Subscribed whenever there is a store path, not only when uploading: the
+		// sink is what writes the file, and its completion is worth reporting even
+		// when nothing is sent anywhere.
+		if (this.options.samplesStorePath) {
 			this.on('client-sink-created', this.handleClientSinkCreated);
+		}
+
+		if (this.options.uploader) {
 			this.on('client-added', this.handleClientAdded);
 			this.on('client-updated', this.handleClientUpdated);
 			this.on('call-closed', this.handleCallClosed);
@@ -171,11 +190,21 @@ export class ObserverService extends Observer {
 	 */
 	private handleClientSinkCreated = ({ sink, observedCall, observedClient }: EventScope<'client-sink-created'>): void => {
 		const sourcePath = sink instanceof JsonlFileSink ? sink.path : undefined;
-		const { uploader } = this.options;
 
-		if (!sourcePath || !uploader) return;
+		if (!sourcePath) return;
 
 		sink.once('close', async () => {
+			// The sink is closed, so the file is complete. Size is included because a
+			// 0-byte file is the tell-tale of a client that connected but never sent
+			// a sample, which otherwise looks identical to success.
+			const bytes = await stat(sourcePath)
+				.then((s) => s.size)
+				.catch(() => -1);
+
+			const { uploader } = this.options;
+
+			if (!uploader) return logger.info('sample file written [clientId: %s, bytes: %d, path: %s]', observedClient.clientId, bytes, sourcePath);
+
 			const call = observedCall as ObservedCall<ObservedCallAppData>;
 			const sampleAttachments = observedClient.attachments as Record<string, unknown> | undefined;
 			const roomId = safeKeySegment(call.appData?.roomId ?? sampleAttachments?.['roomId'], 'unknown-room');
@@ -187,6 +216,8 @@ export class ObserverService extends Observer {
 					sourcePath,
 					contentType: 'application/x-ndjson',
 				});
+
+				logger.info('sample file uploaded [key: %s, bytes: %d] from %s, deletedAfterUpload: %s', targetKey, bytes, sourcePath, String(uploader.deleteAfterUpload));
 
 				if (uploader.deleteAfterUpload) {
 					await this.deleteUploadedFile(sourcePath, targetKey);
@@ -266,6 +297,9 @@ export class ObserverService extends Observer {
 				body: sample,
 				contentType: 'application/json',
 			});
+
+			logger.info('sample file uploaded [key: %s] from call %s', targetKey, observedCall.callId);
+
 		} catch (error) {
 			logger.error({ err: error }, 'handleCallClosed() upload failed [callId: %s]', observedCall.callId);
 		}
@@ -332,6 +366,8 @@ export class ObserverService extends Observer {
 				body: sample,
 				contentType: 'application/json',
 			});
+
+			logger.info('sample file uploaded [key: %s] for router %s', targetKey, observedMediasoupRouter.router.id);
 		} catch (error) {
 			logger.error({ err: error }, 'handleMediasoupRouterRemoved() upload failed [routerId: %s]', observedMediasoupRouter.router.id);
 		}
@@ -344,6 +380,21 @@ export class ObserverService extends Observer {
 	 */
 	public override close(): void {
 		mediasoup.observer.off('newworker', this.handleNewMediasoupWorker);
+
+		this.off('peer-connection-added', this.handlePeerConnectionAdded);
+		this.off('mediasoup-router-added', this.handleMediasoupRouterAdded);
+		this.off('mediasoup-router-matched-with-peer-connection', this.handleMediasoupRouterMatched);
+
+		if (this.options.samplesStorePath) {
+			this.off('client-sink-created', this.handleClientSinkCreated);
+		}
+
+		if (this.options.uploader) {
+			this.off('client-added', this.handleClientAdded);
+			this.off('client-updated', this.handleClientUpdated);
+			this.off('call-closed', this.handleCallClosed);
+			this.off('mediasoup-router-removed', this.handleMediasoupRouterRemoved);
+		}
 
 		super.close();
 	}

--- a/src/ObserverService.ts
+++ b/src/ObserverService.ts
@@ -1,0 +1,351 @@
+import { Logger } from 'edumeet-common';
+import { unlink } from 'fs/promises';
+import { DataConsumer } from 'mediasoup/types';
+import * as mediasoup from 'mediasoup';
+import {
+	createDefaultMediasoupRemoteTrackResolverFactory,
+	createJsonlFileSinkFactory,
+	JsonlFileSink,
+	ObservedCall,
+	Observer,
+	ObserverEvents,
+	setObserverLogger,
+} from '@observertc/observer-js';
+import { Uploader } from './uploader/Uploader';
+
+const logger = new Logger('ObserverService');
+
+/**
+ * `roomId` reaches us inside a client-supplied sample attachment, so it can
+ * never be trusted as a key segment. `encodeURIComponent` does not escape `..`,
+ * so an unchecked value would survive into `HttpUploader.buildUrl()` and let URL
+ * normalisation move the POST outside the configured base path. Anything that
+ * is not a plain, bounded token is replaced by the fallback.
+ */
+const SAFE_KEY_SEGMENT = /^[A-Za-z0-9._-]{1,128}$/;
+
+const safeKeySegment = (value: unknown, fallback: string): string => {
+	if (typeof value !== 'string' || value === '.' || value === '..' || !SAFE_KEY_SEGMENT.test(value)) {
+		if (value !== undefined) logger.warn('safeKeySegment() rejected unsafe segment [value: %s]', String(value));
+
+		return fallback;
+	}
+
+	return value;
+};
+
+setObserverLogger({
+	debug: () => void 0,
+	info: (...args) => logger.debug(...args),
+	warn: (...args) => logger.warn(...args),
+	error: (...args) => logger.error(...args),
+	trace: () => void 0,
+});
+
+export type ObservedCallAppData = {
+	roomId: string | undefined;
+	clients: Record<string, {
+		displayName?: string,
+	}>;
+	routerIds: string[];
+}
+
+export type ObserverServiceOptions = {
+
+	/**
+	 * Directory the per-client JSONL files are written to.
+	 *
+	 * Required for uploading: the observer only creates a file sink when it has
+	 * somewhere to write, and the uploader sends that file. Without it there is
+	 * nothing worth uploading, so `uploader` is ignored.
+	 */
+	samplesStorePath?: string;
+
+	uploader?: Uploader;
+}
+
+export type ObserverServiceEvents = Omit<ObserverEvents, 'observer-closed' | 'sample-rejected'>;
+
+/** The single argument the observer hands a listener for event `K`. */
+type EventScope<K extends keyof ObserverEvents> = ObserverEvents[K][0];
+
+export class ObserverService extends Observer {
+	private static buildObserverConfig(options: ObserverServiceOptions): ConstructorParameters<typeof Observer>[0] {
+		if (options.uploader && !options.samplesStorePath) {
+			logger.warn('buildObserverConfig() ignoring --samplesUploadUri, nothing to upload without --samplesStorePath');
+
+			options.uploader = undefined;
+		}
+
+		return {
+			createClientSink: options.samplesStorePath
+				? createJsonlFileSinkFactory({ directory: options.samplesStorePath })
+				: undefined,
+			closeCallIfEmptyForMs: 5 * 60 * 1000, // 5 minutes
+			closeClientIfIdleForMs: 1 * 60 * 1000, // 1 minute,
+			createRemoteTrackResolver: createDefaultMediasoupRemoteTrackResolverFactory(),
+		};
+	}
+
+	public constructor(public options: ObserverServiceOptions) {
+		super(ObserverService.buildObserverConfig(options));
+
+		logger.debug('constructor()');
+
+		this.setupObserverEvents();
+		this.config.createCallAppData = this.createObservedCallAppData.bind(this);
+	}
+
+	/**
+	 * Register a mediasoup DataProducer that carries observer samples.
+	 * Called from producerMiddleware when label === 'observertc-samples'.
+	 */
+	public addDataConsumer(dataConsumer: DataConsumer): void {
+		logger.debug('addDataConsumer() [id: %s]', dataConsumer.id);
+
+		const onMessage = (payload: Buffer | string) => {
+			try {
+				const text = Buffer.isBuffer(payload)
+					? payload.toString('utf8')
+					: String(payload);
+
+				const sample = JSON.parse(text);
+
+				this.accept(sample);
+			} catch (error) {
+				logger.error(
+					{ err: error },
+					'addDataConsumer() error accepting sample [dataConsumerId: %s]',
+					dataConsumer.id
+				);
+			}
+		};
+
+		dataConsumer.observer.once('close', () => {
+			dataConsumer.off('message', onMessage);
+		});
+		dataConsumer.on('message', onMessage);
+	}
+
+	private createObservedCallAppData(): ObservedCallAppData {
+		return {
+			roomId: undefined, // populated from client sample attachments via 'client-updated'
+			clients: {},
+			routerIds: [],
+		};
+	}
+
+	/**
+	 * Wire up the subscriptions. Each handler is an arrow class property, so it
+	 * stays bound when passed by reference here; those run immediately after
+	 * `super()`, before this method is called.
+	 *
+	 * Only the first group is unconditional. The rest exists solely to produce
+	 * artifacts for the uploader, and to keep the call appData those artifacts
+	 * are built from — `ObservedCallAppData` is read nowhere else. With nowhere to
+	 * send anything, none of that work is worth doing, so we do not subscribe at
+	 * all rather than subscribe and bail out per event.
+	 */
+	private setupObserverEvents(): void {
+		// Diagnostics and observer wiring, worth having either way.
+		this.on('peer-connection-added', this.handlePeerConnectionAdded);
+		this.on('mediasoup-router-added', this.handleMediasoupRouterAdded);
+		this.on('mediasoup-router-matched-with-peer-connection', this.handleMediasoupRouterMatched);
+
+		// Not one of our own events: mediasoup's global observer is how we learn
+		// about routers, so they can be attached to the calls that use them.
+		mediasoup.observer.on('newworker', this.handleNewMediasoupWorker);
+
+		if (this.options.uploader) {
+			this.on('client-sink-created', this.handleClientSinkCreated);
+			this.on('client-added', this.handleClientAdded);
+			this.on('client-updated', this.handleClientUpdated);
+			this.on('call-closed', this.handleCallClosed);
+			this.on('mediasoup-router-removed', this.handleMediasoupRouterRemoved);
+		}
+	}
+
+	/**
+	 * Upload the client's JSONL file once its sink closes, i.e. once the observed
+	 * client has left and nothing more will be written.
+	 */
+	private handleClientSinkCreated = ({ sink, observedCall, observedClient }: EventScope<'client-sink-created'>): void => {
+		const sourcePath = sink instanceof JsonlFileSink ? sink.path : undefined;
+		const { uploader } = this.options;
+
+		if (!sourcePath || !uploader) return;
+
+		sink.once('close', async () => {
+			const call = observedCall as ObservedCall<ObservedCallAppData>;
+			const sampleAttachments = observedClient.attachments as Record<string, unknown> | undefined;
+			const roomId = safeKeySegment(call.appData?.roomId ?? sampleAttachments?.['roomId'], 'unknown-room');
+			const targetKey = `${roomId}/${call.callId}/${observedClient.clientId}.jsonl`;
+
+			try {
+				await uploader.upload({
+					key: targetKey,
+					sourcePath,
+					contentType: 'application/x-ndjson',
+				});
+
+				if (uploader.deleteAfterUpload) {
+					await this.deleteUploadedFile(sourcePath, targetKey);
+				}
+			} catch (error) {
+				logger.error({ err: error }, 'handleClientSinkCreated() upload failed [key: %s]', targetKey);
+			}
+		});
+	};
+
+	private async deleteUploadedFile(path: string, key: string): Promise<void> {
+		try {
+			await unlink(path);
+		} catch (error) {
+			logger.warn({ err: error }, 'deleteUploadedFile() delete failed [key: %s, path: %s]', key, path);
+		}
+	}
+
+	/** Seed the call's appData entry for a client that just joined. */
+	private handleClientAdded = (scope: EventScope<'client-added'>): void => {
+		const observedCall = scope.observedCall as ObservedCall<ObservedCallAppData>;
+
+		observedCall.appData.clients[scope.observedClient.clientId] = {
+
+		};
+	};
+
+	/** Lift roomId and displayName out of client sample attachments onto the call. */
+	private handleClientUpdated = ({ observedClient }: EventScope<'client-updated'>): void => {
+		const observedCall = observedClient.call as ObservedCall<ObservedCallAppData>;
+
+		if (!observedCall.appData?.roomId && observedClient.attachments?.roomId) {
+
+			observedCall.appData.roomId = observedClient.attachments.roomId as string;
+
+			logger.debug('handleClientUpdated() set roomId [callId: %s, roomId: %s]', observedClient.call.callId, observedCall.appData.roomId);
+		}
+
+		// `client-added` may never have been seen for this client, in which case the
+		// entry is absent. Writing through it would throw, and an uncaught throw here
+		// takes the whole media node down via the process-level handler in server.ts.
+		const clientEntry = observedCall.appData?.clients?.[observedClient.clientId];
+
+		if (clientEntry && observedClient.attachments?.displayName) {
+			clientEntry.displayName = observedClient.attachments.displayName as string;
+		}
+	};
+
+	private handlePeerConnectionAdded = ({ observedClient, observedCall, observedPeerConnection }: EventScope<'peer-connection-added'>): void => {
+		logger.debug('handlePeerConnectionAdded() [callId: %s, clientId: %s, peerConnectionId: %s]', observedCall.callId, observedClient.clientId, observedPeerConnection.peerConnectionId);
+	};
+
+	/** Upload the call summary once the call is over. */
+	private handleCallClosed = async (scope: EventScope<'call-closed'>): Promise<void> => {
+		const observedCall = scope.observedCall as ObservedCall<ObservedCallAppData>;
+
+		logger.debug('handleCallClosed() [callId: %s, appData: %o]', observedCall.callId, observedCall.appData);
+
+		const { uploader } = this.options;
+
+		// Nothing reads the summary when there is nowhere to send it, so bail out
+		// before paying to serialise it.
+		if (!uploader || !observedCall.appData) return;
+
+		try {
+			const sample = JSON.stringify({
+				...observedCall.appData,
+				numberOfIssues: observedCall.numberOfIssues,
+				clientsUsedTurn: [ ...observedCall.clientsUsedTurn ],
+			});
+
+			const callRoomId = safeKeySegment(observedCall.appData.roomId, 'unknown-room');
+			const targetKey = `${callRoomId}/${observedCall.callId}/call-summary.json`;
+
+			await uploader.upload({
+				key: targetKey,
+				body: sample,
+				contentType: 'application/json',
+			});
+		} catch (error) {
+			logger.error({ err: error }, 'handleCallClosed() upload failed [callId: %s]', observedCall.callId);
+		}
+	};
+
+	/** Observe every router each mediasoup worker creates. */
+	private handleNewMediasoupWorker = (worker: mediasoup.types.Worker): void => {
+		const onNewRouter = (router: mediasoup.types.Router) => {
+			this.createObservedMediasoupRouter({
+				router,
+				matchPeerConnectionByWebRtcTransportId: true,
+			});
+		};
+
+		worker.observer.once('close', () => {
+			worker.observer.off('newrouter', onNewRouter);
+		});
+		worker.observer.on('newrouter', onNewRouter);
+	};
+
+	private handleMediasoupRouterAdded = ({ observedMediasoupRouter }: EventScope<'mediasoup-router-added'>): void => {
+		logger.debug('handleMediasoupRouterAdded() [routerId: %s, sample: %o]', observedMediasoupRouter.router.id, observedMediasoupRouter.sample);
+	};
+
+	/** Remember which call a router belongs to, and tag the client with its id. */
+	private handleMediasoupRouterMatched = ({ observedClient, observedCall, observedMediasoupRouter }: EventScope<'mediasoup-router-matched-with-peer-connection'>): void => {
+		observedMediasoupRouter.appData = {
+			observedCall,
+		};
+
+		logger.debug('handleMediasoupRouterMatched() [routerId: %s, callId: %s, clientId: %s]', observedMediasoupRouter.router.id, observedCall.callId, observedClient.clientId);
+
+		observedClient.injectAttachment({
+			routerId: observedMediasoupRouter.router.id,
+		});
+
+		const callAppData = (observedCall as ObservedCall<ObservedCallAppData>).appData;
+
+		if (callAppData?.routerIds && !callAppData.routerIds.includes(observedMediasoupRouter.router.id)) {
+			callAppData.routerIds.push(observedMediasoupRouter.router.id);
+		}
+	};
+
+	/** Upload the router's own sample once it goes away. */
+	private handleMediasoupRouterRemoved = async ({ observedMediasoupRouter }: EventScope<'mediasoup-router-removed'>): Promise<void> => {
+		logger.debug('handleMediasoupRouterRemoved() [routerId: %s, sample: %o, appData: %o]', observedMediasoupRouter.router.id, observedMediasoupRouter.sample, observedMediasoupRouter.appData);
+
+		const { uploader } = this.options;
+
+		// The router sample can be sizeable; do not stringify it for nobody.
+		if (!uploader || !observedMediasoupRouter.appData?.observedCall) return;
+
+		const observedCall = observedMediasoupRouter.appData.observedCall as ObservedCall<ObservedCallAppData>;
+
+		if (!observedCall.appData.roomId) return;
+
+		try {
+			const sample = JSON.stringify(observedMediasoupRouter.sample);
+			const roomId = safeKeySegment(observedCall.appData.roomId, 'unknown-room');
+			const targetKey = `${roomId}/${observedCall.callId}/mediasoup-router-${observedMediasoupRouter.router.id}.json`;
+
+			await uploader.upload({
+				key: targetKey,
+				body: sample,
+				contentType: 'application/json',
+			});
+		} catch (error) {
+			logger.error({ err: error }, 'handleMediasoupRouterRemoved() upload failed [routerId: %s]', observedMediasoupRouter.router.id);
+		}
+	};
+
+	/**
+	 * `mediasoup.observer` is a process-level singleton that outlives this
+	 * service, so the 'newworker' subscription has to be released explicitly or
+	 * it keeps the closed ObserverService reachable.
+	 */
+	public override close(): void {
+		mediasoup.observer.off('newworker', this.handleNewMediasoupWorker);
+
+		super.close();
+	}
+
+}

--- a/src/ObserverService.ts
+++ b/src/ObserverService.ts
@@ -64,19 +64,65 @@ export type ObserverServiceOptions = {
 	uploader?: Uploader;
 }
 
+/**
+ * What the constructor accepts, as opposed to what the service settles on.
+ *
+ * `samplesStorePath` is widened here because it arrives straight from minimist,
+ * which yields `true` for a valueless `--samplesStorePath` rather than a string.
+ * Passing that on would reach `createJsonlFileSinkFactory({ directory })` and
+ * take the node down at startup, so the constructor normalises it first;
+ * `service.options` only ever exposes the narrowed form.
+ */
+export type ObserverServiceInput = Omit<ObserverServiceOptions, 'samplesStorePath'> & {
+	samplesStorePath?: unknown;
+}
+
 export type ObserverServiceEvents = Omit<ObserverEvents, 'observer-closed' | 'sample-rejected'>;
 
 /** The single argument the observer hands a listener for event `K`. */
 type EventScope<K extends keyof ObserverEvents> = ObserverEvents[K][0];
 
 export class ObserverService extends Observer {
-	private static buildObserverConfig(options: ObserverServiceOptions): ConstructorParameters<typeof Observer>[0] {
-		if (options.uploader && !options.samplesStorePath) {
-			logger.warn('buildObserverConfig() ignoring --samplesUploadUri, nothing to upload without --samplesStorePath');
+	/**
+	 * Narrow the raw `--samplesStorePath` value to a usable directory, or to
+	 * `undefined` with a warning. Sample storage is a diagnostic, so a malformed
+	 * flag disables it rather than stopping the node from starting.
+	 */
+	private static normalizeStorePath(value: unknown): string | undefined {
+		if (value === undefined) return undefined;
+
+		const directory = typeof value === 'string' ? value.trim() : '';
+
+		if (!directory) {
+			logger.warn(
+				'normalizeStorePath() --samplesStorePath needs a directory, sample storage disabled [value: %s]',
+				String(value)
+			);
+
+			return undefined;
+		}
+
+		return directory;
+	}
+
+	/**
+	 * The options the service actually runs on. This is a private copy: the
+	 * caller's object is never written to, so it stays safe to reuse.
+	 */
+	private static resolveOptions(input: ObserverServiceInput): ObserverServiceOptions {
+		const samplesStorePath = ObserverService.normalizeStorePath(input.samplesStorePath);
+		const options: ObserverServiceOptions = { ...input, samplesStorePath };
+
+		if (options.uploader && !samplesStorePath) {
+			logger.warn('resolveOptions() ignoring --samplesUploadUri, nothing to upload without --samplesStorePath');
 
 			options.uploader = undefined;
 		}
 
+		return options;
+	}
+
+	private static buildObserverConfig(options: ObserverServiceOptions): ConstructorParameters<typeof Observer>[0] {
 		return {
 			createClientSink: options.samplesStorePath
 				? createJsonlFileSinkFactory({ directory: options.samplesStorePath })
@@ -87,8 +133,14 @@ export class ObserverService extends Observer {
 		};
 	}
 
-	public constructor(public options: ObserverServiceOptions) {
+	public readonly options: ObserverServiceOptions;
+
+	public constructor(input: ObserverServiceInput) {
+		const options = ObserverService.resolveOptions(input);
+
 		super(ObserverService.buildObserverConfig(options));
+
+		this.options = options;
 
 		logger.debug('constructor()');
 

--- a/src/RoomServer.ts
+++ b/src/RoomServer.ts
@@ -12,11 +12,13 @@ import { createConsumerMiddleware } from './middlewares/consumerMiddleware';
 import { Logger, Middleware, skipIfClosed } from 'edumeet-common';
 import { createAudioObserverMiddleware } from './middlewares/audioObserverMiddleware';
 import { Router } from 'mediasoup/types';
+import { ObserverService } from './ObserverService';
 
 const logger = new Logger('RoomServer');
 
 export interface RoomServerOptions {
 	mediaService: MediaService;
+	observerService: ObserverService;
 	roomServerConnection: RoomServerConnection;
 	imageTag?: string;
 }
@@ -36,6 +38,7 @@ export default class RoomServer extends EventEmitter {
 
 	constructor({
 		mediaService,
+		observerService,
 		roomServerConnection,
 		imageTag
 	}: RoomServerOptions) {
@@ -50,6 +53,7 @@ export default class RoomServer extends EventEmitter {
 		const middlewareOptions = {
 			roomServer: this,
 			mediaService,
+			observerService,
 		} as MiddlewareOptions;
 
 		this.routerMiddleware = createRouterMiddleware(middlewareOptions);

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,7 +1,9 @@
 import MediaService from '../MediaService';
 import RoomServer from '../RoomServer';
+import { ObserverService } from '../ObserverService';
 
 export interface MiddlewareOptions {
 	roomServer: RoomServer;
 	mediaService: MediaService;
+	observerService: ObserverService;
 }

--- a/src/middlewares/producerMiddleware.ts
+++ b/src/middlewares/producerMiddleware.ts
@@ -7,6 +7,7 @@ const logger = new Logger('ProducerMiddleware');
 
 export const createProducerMiddleware = ({
 	roomServer,
+	observerService,
 }: MiddlewareOptions): Middleware<RoomServerConnectionContext> => {
 	logger.debug('createProducerMiddleware()');
 
@@ -368,6 +369,24 @@ export const createProducerMiddleware = ({
 							});
 						}
 					});
+
+					// Hand observer-monitoring data producers to the ObserverService.
+					if (label === 'observertc-samples') {
+						// Created on demand: routers only get a DirectTransport once a client
+						// actually sends samples, so nodes without collection pay nothing.
+						routerData.directTransport ??= await router.createDirectTransport();
+
+						const dataConsumer = await routerData.directTransport.consumeData({
+							dataProducerId: dataProducer.id,
+						});
+
+						if (!dataConsumer) {
+							dataProducer.close();
+							throw new Error('Failed to consume data producer for ObserverService');
+						}
+
+						observerService.addDataConsumer(dataConsumer);
+					}
 
 					response.id = dataProducer.id;
 					context.handled = true;

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,8 @@ import { Logger } from 'edumeet-common';
 import { createHttpEndpoints } from './httpEndpoints';
 import { IOServerConnection } from './common/IOServerConnection';
 import LoadManager from './LoadManager';
+import { ObserverService } from './ObserverService';
+import { createUploader } from './uploader/Uploader';
 
 const logger = new Logger('MediaNode');
 
@@ -66,6 +68,11 @@ const showUsage = () => {
 	logger.debug('    The interval in ms to poll load usage.\n\n');
 	logger.debug('  --cpuPercentCascadingLimit <percent> (optional, default: 66)');
 	logger.debug('    The CPU usage percent limit to start cascading.\n\n');
+	logger.debug('  --samplesStorePath <path> (optional, default: none)');
+	logger.debug('    Local directory to write observertc JSONL sample files to.\n\n');
+	logger.debug('  --samplesUploadUri <uri> (optional, default: none)');
+	logger.debug('    Upload observertc samples, e.g. "s3://bucket/prefix?region=eu-north-1".');
+	logger.debug('    Requires --samplesStorePath, otherwise it is ignored.\n\n');
 };
 
 const roomServerConnections = new Map<string, RoomServerConnection>();
@@ -131,6 +138,8 @@ export const cancelDrain = () => {
 		loadPollingInterval = 10_000,
 		cpuPercentCascadingLimit = 66,
 		imageTag,
+		samplesStorePath,
+		samplesUploadUri,
 	} = minimist(process.argv.slice(2));
 	
 	if (!ip || help || usage) {
@@ -159,6 +168,11 @@ export const cancelDrain = () => {
 	}, 'Starting...');
 
 	interactiveServer(roomServerConnections, roomServers);
+
+	const observerService = new ObserverService({
+		samplesStorePath,
+		uploader: createUploader(samplesUploadUri),
+	});
 
 	const mediaService = await MediaService.create({
 		ip,
@@ -245,6 +259,7 @@ export const cancelDrain = () => {
 
 		const roomServer = new RoomServer({
 			mediaService,
+			observerService,
 			roomServerConnection,
 			imageTag
 		});
@@ -259,6 +274,7 @@ export const cancelDrain = () => {
 		roomServerConnections.forEach((roomServerConnection) =>
 			roomServerConnection.close());
 		roomServers.forEach((roomServer) => roomServer.close());
+		observerService.close();
 		mediaService.close();
 		httpsServer.close();
 

--- a/src/uploader/HttpUploader.ts
+++ b/src/uploader/HttpUploader.ts
@@ -44,7 +44,9 @@ export class HttpUploader implements Uploader {
 		this.token = config.token;
 		this.maxAttempts = config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
 		this.fetchImpl = fetchImpl;
-		this.deleteAfterUpload = config.deleteAfterUpload ?? false;
+		// An uploader only exists when one was explicitly configured, so staging
+		// files are transient by default and only kept when asked for.
+		this.deleteAfterUpload = config.deleteAfterUpload ?? true;
 	}
 
 	public async upload({ key, body, sourcePath, contentType }: UploadOptions): Promise<void> {

--- a/src/uploader/HttpUploader.ts
+++ b/src/uploader/HttpUploader.ts
@@ -1,0 +1,122 @@
+import { Logger } from 'edumeet-common';
+import { readFile } from 'fs/promises';
+import { HttpConfig } from './samplesUploadUri';
+import { Uploader, UploadOptions } from './Uploader';
+
+const logger = new Logger('HttpUploader');
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const REQUEST_TIMEOUT_MS = 30_000;
+const RETRY_BASE_DELAY_MS = 100;
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** 429 and 5xx are worth another go; other 4xx mean the request itself is wrong. */
+const isRetriable = (status: number): boolean => status === 429 || status >= 500;
+
+/**
+ * POSTs objects to an HTTP endpoint.
+ *
+ * The key is appended to the base path, so a key of `some/path/object.json` is
+ * POSTed to `<baseUrl>/some/path/object.json` with the payload as the raw body.
+ * That mirrors the layout the S3 uploader produces, so a receiver sees the same
+ * hierarchy whichever backend is configured.
+ */
+export class HttpUploader implements Uploader {
+	public readonly stats = {
+		ongoingUploads: 0,
+		completedUploads: 0,
+		failedUploads: 0,
+	};
+	public readonly deleteAfterUpload: boolean;
+
+	private readonly baseUrl: string;
+	private readonly token?: string;
+	private readonly maxAttempts: number;
+	private readonly fetchImpl: typeof fetch;
+
+	/**
+	 * @param config resolved by `parseSamplesUploadUri()`
+	 * @param fetchImpl injectable, primarily so tests can stub the transport
+	 */
+	public constructor(config: HttpConfig, fetchImpl: typeof fetch = fetch) {
+		this.baseUrl = config.url;
+		this.token = config.token;
+		this.maxAttempts = config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+		this.fetchImpl = fetchImpl;
+		this.deleteAfterUpload = config.deleteAfterUpload ?? false;
+	}
+
+	public async upload({ key, body, sourcePath, contentType }: UploadOptions): Promise<void> {
+		this.stats.ongoingUploads++;
+
+		try {
+			const payload = sourcePath !== undefined ? await readFile(sourcePath) : body;
+
+			if (payload === undefined) {
+				throw new Error(`upload() neither body nor sourcePath given [key: ${key}]`);
+			}
+
+			await this.post(this.buildUrl(key), payload, contentType);
+
+			this.stats.completedUploads++;
+		} catch (error) {
+			this.stats.failedUploads++;
+
+			throw error;
+		} finally {
+			this.stats.ongoingUploads--;
+		}
+	}
+
+	/** One logical upload, retried up to `maxAttempts` times. */
+	private async post(target: string, payload: NonNullable<UploadOptions['body']>, contentType: string): Promise<void> {
+		let lastError: Error | undefined;
+
+		for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
+			if (attempt > 1) await delay(RETRY_BASE_DELAY_MS * (2 ** (attempt - 2)));
+
+			let response: Response;
+
+			try {
+				response = await this.fetchImpl(target, {
+					method: 'POST',
+					headers: {
+						'content-type': contentType,
+						...(this.token && { authorization: `Bearer ${this.token}` }),
+					},
+					body: payload,
+					signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+				});
+			} catch (error) {
+				// Network failure or timeout, both worth retrying.
+				lastError = error as Error;
+
+				continue;
+			}
+
+			if (response.ok) {
+				logger.debug('post() uploaded [url: %s, status: %d]', target, response.status);
+
+				return;
+			}
+
+			lastError = new Error(`POST ${target} failed with ${response.status} ${response.statusText}`);
+
+			if (!isRetriable(response.status)) break;
+		}
+
+		throw lastError;
+	}
+
+	/** Append the logical key to the base path, escaping each segment. */
+	private buildUrl(key: string): string {
+		const path = key
+			.split('/')
+			.filter(Boolean)
+			.map(encodeURIComponent)
+			.join('/');
+
+		return `${this.baseUrl}/${path}`;
+	}
+}

--- a/src/uploader/HttpUploader.ts
+++ b/src/uploader/HttpUploader.ts
@@ -15,6 +15,23 @@ const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 const isRetriable = (status: number): boolean => status === 429 || status >= 500;
 
 /**
+ * Release the response body.
+ *
+ * Nothing here ever reads one, and Node's fetch (undici) keeps the underlying
+ * connection tied up until the body is consumed or cancelled. Leaving them
+ * dangling costs us connection reuse and, under retry or load, leaks sockets —
+ * so every response is discarded on every path out of the attempt.
+ */
+const discardBody = async (response: Response): Promise<void> => {
+	try {
+		await response.body?.cancel();
+	} catch {
+		// Already consumed, already errored, or a stubbed fetch with no body at
+		// all. Nothing left to release either way, and the upload does not care.
+	}
+};
+
+/**
  * POSTs objects to an HTTP endpoint.
  *
  * The key is appended to the base path, so a key of `some/path/object.json` is
@@ -96,6 +113,8 @@ export class HttpUploader implements Uploader {
 
 				continue;
 			}
+
+			await discardBody(response);
 
 			if (response.ok) {
 				logger.debug('post() uploaded [url: %s, status: %d]', target, response.status);

--- a/src/uploader/S3Uploader.ts
+++ b/src/uploader/S3Uploader.ts
@@ -1,0 +1,81 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { Logger } from 'edumeet-common';
+import { readFile } from 'fs/promises';
+import { S3Config } from './samplesUploadUri';
+import { Uploader, UploadOptions } from './Uploader';
+
+const logger = new Logger('S3Uploader');
+
+/**
+ * Uploads to S3 or any S3-compatible store.
+ *
+ * Owns the bucket and the optional key prefix from the parsed URI, so callers
+ * pass plain relative keys and never have to know about either.
+ */
+export class S3Uploader implements Uploader {
+	public readonly stats = {
+		ongoingUploads: 0,
+		completedUploads: 0,
+		failedUploads: 0,
+	};
+
+	public readonly deleteAfterUpload: boolean;
+
+	private readonly client: S3Client;
+	private readonly bucket: string;
+	private readonly keyPrefix?: string;
+
+	/**
+	 * @param config resolved by `parseSamplesUploadUri()`
+	 * @param client pre-built client, primarily so tests can inject a stub
+	 */
+	public constructor(config: S3Config, client?: S3Client) {
+		const { bucket, keyPrefix, region, endpoint, forcePathStyle, credentials, maxAttempts } = config;
+
+		this.bucket = bucket;
+		this.keyPrefix = keyPrefix;
+		this.client = client ?? new S3Client({
+			...(region && { region }),
+			...(endpoint && { endpoint }),
+			forcePathStyle,
+			...(credentials && { credentials }),
+			...(maxAttempts && { maxAttempts }),
+		});
+		this.deleteAfterUpload = config.deleteAfterUpload ?? false;
+	}
+
+	public async upload({ key, body, sourcePath, contentType }: UploadOptions): Promise<void> {
+		const targetKey = this.buildKey(key);
+
+		this.stats.ongoingUploads++;
+
+		try {
+			const payload = sourcePath !== undefined ? await readFile(sourcePath) : body;
+
+			if (payload === undefined) {
+				throw new Error(`upload() neither body nor sourcePath given [key: ${targetKey}]`);
+			}
+
+			await this.client.send(new PutObjectCommand({
+				Bucket: this.bucket,
+				Key: targetKey,
+				Body: payload,
+				ContentType: contentType,
+			}));
+
+			logger.debug('upload() uploaded [key: %s]', targetKey);
+			this.stats.completedUploads++;
+		} catch (error) {
+			this.stats.failedUploads++;
+
+			throw error;
+		} finally {
+			this.stats.ongoingUploads--;
+		}
+	}
+
+	/** Prefix a logical key with the optional key prefix from the URI. */
+	private buildKey(key: string): string {
+		return this.keyPrefix ? `${this.keyPrefix}/${key}` : key;
+	}
+}

--- a/src/uploader/S3Uploader.ts
+++ b/src/uploader/S3Uploader.ts
@@ -1,10 +1,18 @@
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { Logger } from 'edumeet-common';
 import { readFile } from 'fs/promises';
 import { S3Config } from './samplesUploadUri';
 import { Uploader, UploadOptions } from './Uploader';
 
+import type { S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
+
 const logger = new Logger('S3Uploader');
+
+type S3Module = typeof import('@aws-sdk/client-s3');
+
+type S3Sdk = {
+	client: S3Client;
+	PutObjectCommand: S3Module['PutObjectCommand'];
+};
 
 /**
  * Uploads to S3 or any S3-compatible store.
@@ -21,9 +29,16 @@ export class S3Uploader implements Uploader {
 
 	public readonly deleteAfterUpload: boolean;
 
-	private readonly client: S3Client;
 	private readonly bucket: string;
 	private readonly keyPrefix?: string;
+	private readonly clientConfig: S3ClientConfig;
+	private readonly injectedClient?: S3Client;
+
+	/** In-flight or settled SDK load; see `ensureSdk()`. */
+	private sdk?: Promise<S3Sdk>;
+
+	/** Set once `ensureSdk()` resolves. Undefined before the first upload. */
+	private client?: S3Client;
 
 	/**
 	 * @param config resolved by `parseSamplesUploadUri()`
@@ -34,14 +49,38 @@ export class S3Uploader implements Uploader {
 
 		this.bucket = bucket;
 		this.keyPrefix = keyPrefix;
-		this.client = client ?? new S3Client({
+		this.injectedClient = client;
+		this.clientConfig = {
 			...(region && { region }),
 			...(endpoint && { endpoint }),
 			forcePathStyle,
 			...(credentials && { credentials }),
 			...(maxAttempts && { maxAttempts }),
+		};
+
+		// An uploader only exists when one was explicitly configured, so staging
+		// files are transient by default and only kept when asked for.
+		this.deleteAfterUpload = config.deleteAfterUpload ?? true;
+	}
+
+	/**
+	 * `@aws-sdk/client-s3` is a large require() graph, so it is pulled in on the
+	 * first upload rather than at module load. Media nodes without an `s3://`
+	 * upload URI never construct this class, and so never pay for the SDK.
+	 *
+	 * The promise is memoised, so concurrent uploads share a single import and a
+	 * single client.
+	 */
+	private async ensureSdk(): Promise<S3Sdk> {
+		this.sdk ??= import('@aws-sdk/client-s3').then(({ S3Client: S3ClientCtor, PutObjectCommand }) => {
+			this.client = this.injectedClient ?? new S3ClientCtor(this.clientConfig);
+
+			logger.debug('ensureSdk() aws sdk loaded [bucket: %s]', this.bucket);
+
+			return { client: this.client, PutObjectCommand };
 		});
-		this.deleteAfterUpload = config.deleteAfterUpload ?? false;
+
+		return this.sdk;
 	}
 
 	public async upload({ key, body, sourcePath, contentType }: UploadOptions): Promise<void> {
@@ -56,7 +95,9 @@ export class S3Uploader implements Uploader {
 				throw new Error(`upload() neither body nor sourcePath given [key: ${targetKey}]`);
 			}
 
-			await this.client.send(new PutObjectCommand({
+			const { client, PutObjectCommand } = await this.ensureSdk();
+
+			await client.send(new PutObjectCommand({
 				Bucket: this.bucket,
 				Key: targetKey,
 				Body: payload,

--- a/src/uploader/Uploader.ts
+++ b/src/uploader/Uploader.ts
@@ -1,0 +1,105 @@
+import { Logger } from 'edumeet-common';
+import { describeSamplesUploadConfig, parseSamplesUploadUri, SamplesUploadConfig } from './samplesUploadUri';
+import { S3Uploader } from './S3Uploader';
+import { HttpUploader } from './HttpUploader';
+
+const logger = new Logger('Uploader');
+
+export type UploadBody = string | Uint8Array | Buffer;
+
+/**
+ * A destination for uploaded objects.
+ *
+ * Keys are logical and relative, e.g. `some/path/object.json`. Where that
+ * actually lands — bucket, key prefix, base URL — is the implementation's
+ * business, so nothing above this type needs to know which backend is in use.
+ *
+ * Nothing here is specific to observertc, or to this service: an uploader is
+ * just "somewhere bytes go, addressed by key".
+ */
+/*
+ * The base no-unused-vars rule does not understand type-level parameter names,
+ * so it flags the ones below. They are documentation, not bindings.
+ */
+/* eslint-disable no-unused-vars */
+export type UploadOptions = {
+
+	/** Logical, relative key, e.g. `some/path/object.json`. */
+	key: string;
+
+	/** In-memory payload. Ignored when `sourcePath` is given. */
+	body?: UploadBody;
+
+	/** Read the payload from this file instead. Takes precedence over `body`. */
+	sourcePath?: string;
+	contentType: string;
+};
+
+export type Uploader = {
+	stats?: {
+		ongoingUploads: number;
+		completedUploads: number;
+		failedUploads: number;
+	};
+	deleteAfterUpload: boolean;
+
+	upload(options: UploadOptions): Promise<void>;
+}
+/* eslint-enable no-unused-vars */
+
+/**
+ * One case per member of SamplesUploadConfig.
+ *
+ * The return type deliberately excludes undefined, so adding a member to that
+ * union without a case here fails to compile rather than quietly yielding "no
+ * uploader".
+ */
+const buildUploader = (config: SamplesUploadConfig): Uploader => {
+	switch (config.type) {
+		case 's3':
+			return new S3Uploader(config);
+
+		case 'http':
+			return new HttpUploader(config);
+	}
+};
+
+/**
+ * Build the uploader described by an upload URI.
+ *
+ * This is the one place in the folder tied to how this service is configured:
+ * the URI comes from `--samplesUploadUri` and is parsed by `samplesUploadUri`.
+ * The uploaders it returns are not — point a different parser at them and they
+ * work unchanged.
+ *
+ * Returns undefined when uploads should stay off: either no value was given, or
+ * it was malformed, in which case the reason is logged. Never throws, so a bad
+ * flag degrades to "no uploads" instead of taking the media node down.
+ *
+ * The value is typed `unknown` because it arrives straight from minimist, which
+ * yields a boolean for a valueless `--samplesUploadUri` rather than a string.
+ */
+export const createUploader = (uri: unknown): Uploader | undefined => {
+	if (uri === undefined) return undefined;
+
+	if (typeof uri !== 'string') {
+		logger.warn('createUploader() --samplesUploadUri needs a value, uploads disabled [example: s3://my-bucket]');
+
+		return undefined;
+	}
+
+	let config: SamplesUploadConfig;
+
+	try {
+		config = parseSamplesUploadUri(uri);
+	} catch (error) {
+		logger.warn('createUploader() uploads disabled [reason: %s]', (error as Error).message);
+
+		return undefined;
+	}
+
+	// Safe to log: the resolved config holds credential references, not values.
+	logger.debug('createUploader() uploads enabled [config: %o]', describeSamplesUploadConfig(config));
+
+	return buildUploader(config);
+};

--- a/src/uploader/samplesUploadUri.ts
+++ b/src/uploader/samplesUploadUri.ts
@@ -1,0 +1,393 @@
+/**
+ * Parser for the `--samplesUploadUri` value.
+ *
+ * The URI scheme picks the kind of upload target, and the parsed result is a
+ * discriminated union so callers can switch on `type` rather than guess:
+ * `s3://` for object storage, `http://` / `https://` to POST at a collector.
+ *
+ * The URI describes *where* samples go and *how* to reach the store. It never
+ * carries credentials: identity is resolved separately, either by the AWS SDK
+ * default credential chain (IRSA, instance profile, AWS_* env vars,
+ * ~/.aws/credentials together with AWS_PROFILE) or, when `credentialsEnv` is
+ * given, from a named set of prefixed environment variables.
+ *
+ * s3:// format:
+ *   s3://<bucket>[/<keyPrefix>][?<param>=<value>&...]
+ *
+ * s3:// parameters:
+ *   endpoint       Custom S3-compatible endpoint URL (MinIO, Ceph, ...).
+ *   region         AWS region. Falls back to AWS_REGION / AWS_DEFAULT_REGION.
+ *   pathStyle      Force path-style URLs. Defaults to true when an endpoint is
+ *                  set, false otherwise.
+ *   credentialsEnv Name prefix of the env vars holding static credentials, e.g.
+ *                  `MINIO` reads MINIO_ACCESS_KEY_ID / MINIO_SECRET_ACCESS_KEY
+ *                  and optionally MINIO_SESSION_TOKEN.
+ *   maxAttempts    SDK retry attempts per request (>= 1).
+ *   deleteAfterUpload Delete staged per-client JSONL files after successful upload.
+ *
+ * http(s):// format:
+ *   http[s]://<host>[:<port>][/<basePath>][?<param>=<value>&...]
+ *
+ * Object keys are appended to the base path, so a key of
+ * `room/call/client.jsonl` is POSTed to `<basePath>/room/call/client.jsonl`.
+ *
+ * http(s):// parameters:
+ *   credentialsEnv Name prefix of the env var holding a bearer token, e.g.
+ *                  `COLLECTOR` reads COLLECTOR_TOKEN.
+ *   maxAttempts    Request attempts before giving up (>= 1, default 3).
+ *   deleteAfterUpload Delete staged per-client JSONL files after successful upload.
+ */
+
+export type S3Credentials = {
+	accessKeyId: string;
+	secretAccessKey: string;
+	sessionToken?: string;
+};
+
+/** Target described by an `s3://` value. */
+export type S3Config = {
+	type: 's3';
+	bucket: string;
+	keyPrefix?: string;
+	region?: string;
+	endpoint?: string;
+	forcePathStyle: boolean;
+	credentials?: S3Credentials;
+	credentialsEnv?: string;
+	maxAttempts?: number;
+	deleteAfterUpload?: boolean;
+};
+
+/** Target described by an `http://` or `https://` value. */
+export type HttpConfig = {
+	type: 'http';
+
+	/** Base URL with the query string stripped and no trailing slash. */
+	url: string;
+
+	/** Bearer token resolved from `credentialsEnv`, if one was given. */
+	token?: string;
+	credentialsEnv?: string;
+	maxAttempts?: number;
+	deleteAfterUpload?: boolean;
+};
+
+/**
+ * Every upload target a `--samplesUploadUri` value can describe, discriminated
+ * by `type`.
+ *
+ * Adding one means adding it to this union, then handling it in
+ * `describeSamplesUploadConfig()` and in `createUploader()`. The compiler flags
+ * both of those. It cannot flag the scheme switch in `parseSamplesUploadUri()`,
+ * which branches on the URI scheme rather than on this type, so that one is on
+ * you.
+ */
+export type SamplesUploadConfig = S3Config | HttpConfig;
+
+export class SamplesUploadUriError extends Error {
+	public constructor(message: string) {
+		super(message);
+		this.name = 'SamplesUploadUriError';
+	}
+}
+
+const S3_PARAMS = [ 'endpoint', 'region', 'pathStyle', 'credentialsEnv', 'maxAttempts', 'deleteAfterUpload' ];
+const HTTP_PARAMS = [ 'credentialsEnv', 'maxAttempts', 'deleteAfterUpload' ];
+
+/** S3 (and MinIO) bucket naming rules, loosely enforced. */
+const BUCKET_PATTERN = /^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/;
+
+const CREDENTIALS_ENV_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+const TRUE_VALUES = [ 'true', '1', 'yes', 'on' ];
+const FALSE_VALUES = [ 'false', '0', 'no', 'off' ];
+
+const parseBooleanParam = (name: string, value: string): boolean => {
+	const normalized = value.trim().toLowerCase();
+
+	if (TRUE_VALUES.includes(normalized)) return true;
+	if (FALSE_VALUES.includes(normalized)) return false;
+
+	throw new SamplesUploadUriError(`--samplesUploadUri: "${name}" must be a boolean (true/false), got "${value}"`);
+};
+
+const parseEndpointParam = (value: string): string => {
+	let endpoint: URL;
+
+	try {
+		endpoint = new URL(value);
+	} catch {
+		throw new SamplesUploadUriError(`--samplesUploadUri: "endpoint" is not a valid URL: "${value}"`);
+	}
+
+	if (endpoint.protocol !== 'http:' && endpoint.protocol !== 'https:') {
+		throw new SamplesUploadUriError(`--samplesUploadUri: "endpoint" must be an http(s) URL, got "${value}"`);
+	}
+
+	return value;
+};
+
+const parseMaxAttemptsParam = (value: string): number => {
+	const maxAttempts = Number.parseInt(value, 10);
+
+	if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+		throw new SamplesUploadUriError(`--samplesUploadUri: "maxAttempts" must be an integer >= 1, got "${value}"`);
+	}
+
+	return maxAttempts;
+};
+
+/**
+ * Resolve static credentials from a named env var prefix.
+ *
+ * This exists so a node can address a store the ambient AWS credential chain
+ * does not point at (typically MinIO) without squatting on the global
+ * AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY variables.
+ */
+const resolveCredentialsFromEnv = (prefix: string, env: NodeJS.ProcessEnv): S3Credentials => {
+	if (!CREDENTIALS_ENV_PATTERN.test(prefix)) {
+		throw new SamplesUploadUriError(`--samplesUploadUri: "credentialsEnv" must be a valid env var name prefix, got "${prefix}"`);
+	}
+
+	const normalized = prefix.toUpperCase();
+	const accessKeyIdVar = `${normalized}_ACCESS_KEY_ID`;
+	const secretAccessKeyVar = `${normalized}_SECRET_ACCESS_KEY`;
+	const sessionToken = env[`${normalized}_SESSION_TOKEN`];
+	const accessKeyId = env[accessKeyIdVar];
+	const secretAccessKey = env[secretAccessKeyVar];
+
+	if (!accessKeyId || !secretAccessKey) {
+		const missing = [
+			...(accessKeyId ? [] : [ accessKeyIdVar ]),
+			...(secretAccessKey ? [] : [ secretAccessKeyVar ]),
+		];
+
+		throw new SamplesUploadUriError(`--samplesUploadUri: credentialsEnv=${prefix} requires ${missing.join(' and ')} to be set`);
+	}
+
+	return {
+		accessKeyId,
+		secretAccessKey,
+		...(sessionToken && { sessionToken }),
+	};
+};
+
+/**
+ * Resolve a bearer token from a named env var prefix, mirroring the S3 helper
+ * above: the URI names the variable, never the value.
+ */
+const resolveTokenFromEnv = (prefix: string, env: NodeJS.ProcessEnv): string => {
+	if (!CREDENTIALS_ENV_PATTERN.test(prefix)) {
+		throw new SamplesUploadUriError(`--samplesUploadUri: "credentialsEnv" must be a valid env var name prefix, got "${prefix}"`);
+	}
+
+	const tokenVar = `${prefix.toUpperCase()}_TOKEN`;
+	const token = env[tokenVar];
+
+	if (!token) {
+		throw new SamplesUploadUriError(`--samplesUploadUri: credentialsEnv=${prefix} requires ${tokenVar} to be set`);
+	}
+
+	return token;
+};
+
+const assertNoUserInfo = (url: URL): void => {
+	if (!url.username && !url.password) return;
+
+	throw new SamplesUploadUriError(
+		'--samplesUploadUri: credentials must not be embedded in the URI (they leak through `ps`, pod specs and logs). ' +
+		'Use the AWS credential chain, or "?credentialsEnv=<PREFIX>" to read them from ' +
+		'<PREFIX>_ACCESS_KEY_ID / <PREFIX>_SECRET_ACCESS_KEY.'
+	);
+};
+
+const assertKnownParams = (url: URL, allowed: string[]): void => {
+	const unknown = [ ...url.searchParams.keys() ].filter((key) => !allowed.includes(key));
+
+	if (unknown.length === 0) return;
+
+	throw new SamplesUploadUriError(`--samplesUploadUri: unknown parameter(s) ${unknown.join(', ')}. Supported: ${allowed.join(', ')}`);
+};
+
+const normalizeS3Input = (value: string): string => {
+	if (/^s3:\/\//i.test(value)) return value;
+
+	// The former `bucket//endpoint` shorthand. Reject it loudly rather than
+	// silently reinterpreting it as a bucket followed by an empty path segment.
+	if (value.includes('//')) {
+		const [ bucket, ...rest ] = value.split('//');
+
+		throw new SamplesUploadUriError(
+			'--samplesUploadUri: the "bucket//endpoint" form is no longer supported. ' +
+			`Use "s3://${bucket}?endpoint=${rest.join('//')}" instead.`
+		);
+	}
+
+	// Bare bucket shorthand, e.g. `--samplesUploadUri my-bucket`.
+	return `s3://${value}`;
+};
+
+const parseS3Uri = (value: string, env: NodeJS.ProcessEnv): S3Config => {
+	const normalized = normalizeS3Input(value);
+	let url: URL;
+
+	try {
+		url = new URL(normalized);
+	} catch {
+		throw new SamplesUploadUriError(`--samplesUploadUri: not a valid URI: "${value}"`);
+	}
+
+	assertNoUserInfo(url);
+	assertKnownParams(url, S3_PARAMS);
+
+	const bucket = url.hostname;
+
+	if (!BUCKET_PATTERN.test(bucket)) {
+		throw new SamplesUploadUriError(
+			`--samplesUploadUri: "${bucket}" is not a valid bucket name (3-63 characters, lowercase letters, digits, dots and hyphens)`
+		);
+	}
+
+	const keyPrefix = decodeURIComponent(url.pathname).replace(/^\/+|\/+$/g, '') || undefined;
+	const endpointParam = url.searchParams.get('endpoint');
+	const pathStyleParam = url.searchParams.get('pathStyle');
+	const regionParam = url.searchParams.get('region');
+	const maxAttemptsParam = url.searchParams.get('maxAttempts');
+	const credentialsEnv = url.searchParams.get('credentialsEnv') ?? undefined;
+	const endpoint = endpointParam ? parseEndpointParam(endpointParam) : undefined;
+	const deleteAfterUploadParam = url.searchParams.get('deleteAfterUpload');
+	const deleteAfterUpload = deleteAfterUploadParam !== null
+		? parseBooleanParam('deleteAfterUpload', deleteAfterUploadParam)
+		: undefined;
+
+	// Most S3-compatible stores need path-style addressing and AWS does not, but
+	// some compatible stores do serve virtual-host style, so keep it overridable.
+	const forcePathStyle = pathStyleParam !== null
+		? parseBooleanParam('pathStyle', pathStyleParam)
+		: Boolean(endpoint);
+
+	// A custom endpoint usually ignores the region, but the SDK insists on one.
+	const region = regionParam
+		?? env.AWS_REGION
+		?? env.AWS_DEFAULT_REGION
+		?? (endpoint ? 'us-east-1' : undefined);
+
+	return {
+		type: 's3',
+		bucket,
+		...(keyPrefix && { keyPrefix }),
+		...(region && { region }),
+		...(endpoint && { endpoint }),
+		forcePathStyle,
+		...(credentialsEnv && {
+			credentialsEnv,
+			credentials: resolveCredentialsFromEnv(credentialsEnv, env),
+		}),
+		...(maxAttemptsParam && { maxAttempts: parseMaxAttemptsParam(maxAttemptsParam) }),
+		...(deleteAfterUpload !== undefined && { deleteAfterUpload }),
+	};
+};
+
+const parseHttpUri = (value: string, env: NodeJS.ProcessEnv): HttpConfig => {
+	let url: URL;
+
+	try {
+		url = new URL(value);
+	} catch {
+		throw new SamplesUploadUriError(`--samplesUploadUri: not a valid URI: "${value}"`);
+	}
+
+	assertNoUserInfo(url);
+	assertKnownParams(url, HTTP_PARAMS);
+
+	const credentialsEnv = url.searchParams.get('credentialsEnv') ?? undefined;
+	const maxAttemptsParam = url.searchParams.get('maxAttempts');
+	const token = credentialsEnv ? resolveTokenFromEnv(credentialsEnv, env) : undefined;
+	const deleteAfterUploadParam = url.searchParams.get('deleteAfterUpload');
+	const deleteAfterUpload = deleteAfterUploadParam !== null
+		? parseBooleanParam('deleteAfterUpload', deleteAfterUploadParam)
+		: undefined;
+
+	// Keys are appended to the base path, so the query string is not part of it.
+	url.search = '';
+
+	const base = url.toString().replace(/\/+$/, '');
+
+	return {
+		type: 'http',
+		url: base,
+		...(credentialsEnv && { credentialsEnv, token }),
+		...(maxAttemptsParam && { maxAttempts: parseMaxAttemptsParam(maxAttemptsParam) }),
+		...(deleteAfterUpload !== undefined && { deleteAfterUpload }),
+	};
+};
+
+/** Scheme of a URI, or undefined for the bare bucket shorthand. */
+const schemeOf = (value: string): string | undefined =>
+	(/^([a-z][a-z0-9+.-]*):\/\//i.exec(value)?.[1])?.toLowerCase();
+
+/**
+ * Parse a `--samplesUploadUri` value into the config for its target kind.
+ *
+ * @throws SamplesUploadUriError when the value is malformed or names a scheme
+ * that is not supported.
+ */
+export const parseSamplesUploadUri = (raw: string, env: NodeJS.ProcessEnv = process.env): SamplesUploadConfig => {
+	const value = raw.trim();
+
+	if (!value) throw new SamplesUploadUriError('--samplesUploadUri: value must not be empty');
+
+	const scheme = schemeOf(value);
+
+	switch (scheme) {
+		// No scheme at all is the bare bucket shorthand, e.g. "my-bucket".
+		case undefined:
+		case 's3':
+			return parseS3Uri(value, env);
+
+		case 'http':
+		case 'https':
+			return parseHttpUri(value, env);
+
+		default:
+			throw new SamplesUploadUriError(`--samplesUploadUri: unsupported scheme "${scheme}://", got "${value}". Supported: s3://, http://, https://`);
+	}
+};
+
+const describeS3Config = (config: S3Config): Record<string, unknown> => ({
+	type: config.type,
+	bucket: config.bucket,
+	keyPrefix: config.keyPrefix ?? '<none>',
+	endpoint: config.endpoint ?? 'AWS',
+	region: config.region ?? '<sdk default>',
+	forcePathStyle: config.forcePathStyle,
+	credentials: config.credentialsEnv
+		? `env:${config.credentialsEnv.toUpperCase()}_*`
+		: 'sdk default chain',
+	deleteAfterUpload: config.deleteAfterUpload ?? false,
+	...(config.maxAttempts && { maxAttempts: config.maxAttempts }),
+});
+
+const describeHttpConfig = (config: HttpConfig): Record<string, unknown> => ({
+	type: config.type,
+	url: config.url,
+	credentials: config.credentialsEnv
+		? `env:${config.credentialsEnv.toUpperCase()}_TOKEN`
+		: 'none',
+	deleteAfterUpload: config.deleteAfterUpload ?? false,
+	...(config.maxAttempts && { maxAttempts: config.maxAttempts }),
+});
+
+/**
+ * A log-safe rendering of the resolved config. Safe by construction: the URI
+ * holds credential *references* only, and resolved secret values are omitted.
+ */
+export const describeSamplesUploadConfig = (config: SamplesUploadConfig): Record<string, unknown> => {
+	switch (config.type) {
+		case 's3':
+			return describeS3Config(config);
+
+		case 'http':
+			return describeHttpConfig(config);
+	}
+};

--- a/src/uploader/samplesUploadUri.ts
+++ b/src/uploader/samplesUploadUri.ts
@@ -364,7 +364,7 @@ const describeS3Config = (config: S3Config): Record<string, unknown> => ({
 	credentials: config.credentialsEnv
 		? `env:${config.credentialsEnv.toUpperCase()}_*`
 		: 'sdk default chain',
-	deleteAfterUpload: config.deleteAfterUpload ?? false,
+	deleteAfterUpload: config.deleteAfterUpload ?? true,
 	...(config.maxAttempts && { maxAttempts: config.maxAttempts }),
 });
 
@@ -374,7 +374,7 @@ const describeHttpConfig = (config: HttpConfig): Record<string, unknown> => ({
 	credentials: config.credentialsEnv
 		? `env:${config.credentialsEnv.toUpperCase()}_TOKEN`
 		: 'none',
-	deleteAfterUpload: config.deleteAfterUpload ?? false,
+	deleteAfterUpload: config.deleteAfterUpload ?? true,
 	...(config.maxAttempts && { maxAttempts: config.maxAttempts }),
 });
 

--- a/src/uploader/samplesUploadUri.ts
+++ b/src/uploader/samplesUploadUri.ts
@@ -31,6 +31,10 @@
  * Object keys are appended to the base path, so a key of
  * `room/call/client.jsonl` is POSTed to `<basePath>/room/call/client.jsonl`.
  *
+ * Fragments are rejected rather than carried: a `#...` never leaves the process,
+ * so a base that ends in one would quietly send every upload to the path in
+ * front of it instead of where the value appears to point.
+ *
  * http(s):// parameters:
  *   credentialsEnv Name prefix of the env var holding a bearer token, e.g.
  *                  `COLLECTOR` reads COLLECTOR_TOKEN.
@@ -201,6 +205,20 @@ const assertNoUserInfo = (url: URL): void => {
 	);
 };
 
+/**
+ * A fragment is never sent over the wire: it is stripped before the request
+ * leaves the process. Keeping one would silently move uploads elsewhere — with
+ * a base of `https://host/path#frag` the appended key becomes part of the
+ * fragment and the POST lands on `/path` — so say so instead of guessing.
+ */
+const assertNoFragment = (url: URL, value: string): void => {
+	if (!url.hash) return;
+
+	throw new SamplesUploadUriError(
+		`--samplesUploadUri: a URI fragment ("${url.hash}") is not supported, it is never sent in a request: "${value}"`
+	);
+};
+
 const assertKnownParams = (url: URL, allowed: string[]): void => {
 	const unknown = [ ...url.searchParams.keys() ].filter((key) => !allowed.includes(key));
 
@@ -238,6 +256,7 @@ const parseS3Uri = (value: string, env: NodeJS.ProcessEnv): S3Config => {
 	}
 
 	assertNoUserInfo(url);
+	assertNoFragment(url, value);
 	assertKnownParams(url, S3_PARAMS);
 
 	const bucket = url.hostname;
@@ -298,6 +317,7 @@ const parseHttpUri = (value: string, env: NodeJS.ProcessEnv): HttpConfig => {
 	}
 
 	assertNoUserInfo(url);
+	assertNoFragment(url, value);
 	assertKnownParams(url, HTTP_PARAMS);
 
 	const credentialsEnv = url.searchParams.get('credentialsEnv') ?? undefined;

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,19 @@
+{
+	"extends": "@tsconfig/node24/tsconfig.json",
+	"compilerOptions": {
+		"experimentalDecorators": true,
+		"resolveJsonModule": true,
+
+		// ts-jest downgrades module resolution unless isolatedModules is on (TS151002),
+		// and without nodenext resolution it cannot follow the "exports" map that
+		// mediasoup uses for its `mediasoup/types` entry point.
+		"isolatedModules": true,
+
+		// The existing suites import deep paths such as `mediasoup/node/lib/Router`,
+		// which the "exports" map does not publish even though the files ship. Mapping
+		// them here keeps those tests working without rewriting their imports.
+		"paths": {
+			"mediasoup/node/lib/*": [ "./node_modules/mediasoup/node/lib/*" ]
+		}
+	}
+}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -4,15 +4,21 @@
 		"experimentalDecorators": true,
 		"resolveJsonModule": true,
 
-		// ts-jest downgrades module resolution unless isolatedModules is on (TS151002),
-		// and without nodenext resolution it cannot follow the "exports" map that
-		// mediasoup uses for its `mediasoup/types` entry point.
-		"isolatedModules": true,
+		// Jest runs CommonJS. Under the inherited "nodenext" module setting
+		// TypeScript preserves `import()` verbatim, and jest's CJS VM then rejects
+		// it with "A dynamic import callback was invoked without
+		// --experimental-vm-modules". Compiling to CommonJS downlevels the lazy AWS
+		// SDK load in S3Uploader to a require(), which jest resolves fine. The
+		// production build uses src/tsconfig.json, so the shipped code keeps native
+		// import() and the SDK stays lazily loaded at runtime.
+		"module": "commonjs",
+		"moduleResolution": "node10",
 
-		// The existing suites import deep paths such as `mediasoup/node/lib/Router`,
-		// which the "exports" map does not publish even though the files ship. Mapping
-		// them here keeps those tests working without rewriting their imports.
+		// Node10 resolution ignores the "exports" map, so mediasoup's subpath entry
+		// points have to be mapped explicitly: `mediasoup/types` for src, and the
+		// deep `mediasoup/node/lib/*` paths the existing suites still import.
 		"paths": {
+			"mediasoup/types": [ "./node_modules/mediasoup/node/lib/types" ],
 			"mediasoup/node/lib/*": [ "./node_modules/mediasoup/node/lib/*" ]
 		}
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,14 +1207,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@observertc/observer-js@npm:1.0.0-beta.12":
-  version: 1.0.0-beta.12
-  resolution: "@observertc/observer-js@npm:1.0.0-beta.12"
+"@observertc/observer-js@npm:1.0.0-beta.13":
+  version: 1.0.0-beta.13
+  resolution: "@observertc/observer-js@npm:1.0.0-beta.13"
   dependencies:
     "@bufbuild/protobuf": "npm:1.1.1"
     events: "npm:^3.3.0"
-    uuid: "npm:^8.3.2"
-  checksum: 10c0/43ef3f9f5539fadb2be523aff4e06e2c08b0462a6998b730481fb33971448e6a2d36204a4f858a856bb8533f625b579c0141bacd426869089247dc48d2bad25d
+    uuid: "npm:^11.1.1"
+  checksum: 10c0/9abf03310ccca346ec956fd2ae9e67e4369fa1d3357ffd1ee40c8b1288828795dfc8cd3c259066ddf9ce17895d10b70febe7d2a5f0f5b0a6b1d55ba86e2e91e2
   languageName: node
   linkType: hard
 
@@ -2416,7 +2416,7 @@ __metadata:
   resolution: "edumeet-media-node@workspace:."
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.1102.0"
-    "@observertc/observer-js": "npm:1.0.0-beta.12"
+    "@observertc/observer-js": "npm:1.0.0-beta.13"
     "@tsconfig/node24": "npm:^24.0.4"
     "@types/debug": "npm:^4.1.13"
     "@types/jest": "npm:^30.0.0"
@@ -5185,12 +5185,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,261 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@aws-sdk/checksums@npm:^3.1000.25":
+  version: 3.1000.25
+  resolution: "@aws-sdk/checksums@npm:3.1000.25"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/ecccb428626cd270e2077fc4785ccb1848ff773edebea2dda07b422fb37109da17c84bf9233627b0c731197491eb22aa4fb6c3366cbb410001da01b7b4aca899
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-s3@npm:^3.1102.0":
+  version: 3.1102.0
+  resolution: "@aws-sdk/client-s3@npm:3.1102.0"
+  dependencies:
+    "@aws-sdk/checksums": "npm:^3.1000.25"
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.77"
+    "@aws-sdk/middleware-sdk-s3": "npm:^3.972.71"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.43"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/fetch-http-handler": "npm:^5.6.13"
+    "@smithy/node-http-handler": "npm:^4.9.13"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b718e245846f3bf2f0ff509ca190a981739300b56ff0756cc4491d8c3095d87ef76e28347b712590e594b1693b176cb469679caeea9de5e74923c109308c579c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/core@npm:^3.977.5":
+  version: 3.977.5
+  resolution: "@aws-sdk/core@npm:3.977.5"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@aws-sdk/xml-builder": "npm:^3.972.37"
+    "@aws/lambda-invoke-store": "npm:^0.3.0"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/signature-v4": "npm:^5.6.12"
+    "@smithy/types": "npm:^4.16.1"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/fadc607ce26b94be7c2ea4136a2b1eb27b95b7ba574c3651ea7d9fc67a92cad7a85f0d4b7e57de0fc10a0e79c032cbe3f28de1386251d00983546050a5137af4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:^3.972.66":
+  version: 3.972.66
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.66"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/ba9b13995eeac9ae3dee16626e0a1d02db818134414e85afa7c84591a4a9ab599afc5e0a4bb28f7a1eafafc136fd9677d2f5fceeaedbde5ee5064afd97e99146
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:^3.972.68":
+  version: 3.972.68
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.68"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/fetch-http-handler": "npm:^5.6.13"
+    "@smithy/node-http-handler": "npm:^4.9.13"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7d5a4488988c2ff2a5cf328f2af00536d98803efab654b3a3f8aa104cfb84914bff917c738bced34d84673681b7c8c91ec9db841754b365ee2a6bd925c68ef86
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:^3.973.11":
+  version: 3.973.11
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.973.11"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.66"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.68"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.73"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.66"
+    "@aws-sdk/credential-provider-sso": "npm:^3.973.10"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.72"
+    "@aws-sdk/nested-clients": "npm:^3.997.40"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/credential-provider-imds": "npm:^4.4.16"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/71570ca3dbb7a6f846a05e52d930c35d9982cbdca10dc62ae382dc0f870f4fe06680f58bc439f21a5de68a423a590f2532058255d079c9af219111ef387a3260
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-login@npm:^3.972.73":
+  version: 3.972.73
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.73"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/nested-clients": "npm:^3.997.40"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4116f5e20df80ffe15d4a1e605c41458969194f2b3a5bf4370dde4cd37a9c7dc40150087c4aac7b1b4648511b1638c3c6256fc07a9b1c97687d3f15d52bad782
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:^3.972.77":
+  version: 3.972.77
+  resolution: "@aws-sdk/credential-provider-node@npm:3.972.77"
+  dependencies:
+    "@aws-sdk/credential-provider-env": "npm:^3.972.66"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.68"
+    "@aws-sdk/credential-provider-ini": "npm:^3.973.11"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.66"
+    "@aws-sdk/credential-provider-sso": "npm:^3.973.10"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.72"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/credential-provider-imds": "npm:^4.4.16"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/5ad7585347ac94cf3da4af2cd8cc0c2ddb1af423172d63f083410ffd7b6e3479190ae0d7a67a579a5bbd5ce26ad23f17356cbbcd0419e64105e62650108c556d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:^3.972.66":
+  version: 3.972.66
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.66"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/726cda0db2fb41702febbe78cdefa28d0883e88cf1c52ac1655791b64c682373462bb80b1956d7bf968c0bba20ee82b6c707a0d83d2301a38852ba35671275a1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:^3.973.10":
+  version: 3.973.10
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.973.10"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/nested-clients": "npm:^3.997.40"
+    "@aws-sdk/token-providers": "npm:3.1102.0"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/df56693725d363ac65ad88dc7683ea76eba5e4a9d3f2ef664e78e685565dfdfc4e3fb071b0c620244da271a5a73d9a68bfd6cb4bdd0f98ef00f9e45967429121
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.72":
+  version: 3.972.72
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.72"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/nested-clients": "npm:^3.997.40"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/27a3ffb50d08a42d243e7ef3a0fa10fe9a3fbe5961da9ca35e9b46eb10512e1ba63533c3c4ac2da100db01bb1707f9890c3fb88e74053d5e334799c7c7064953
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:^3.972.71":
+  version: 3.972.71
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.972.71"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.43"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2aa892a142387df4884c4ff766fc2d9c060402210cc1a2610a16ace684dc74cfae75fccfa076a276e65fd6ae2c7f6465f7864b8691ff7d28e2a206e7e8f1eb57
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:^3.997.40":
+  version: 3.997.40
+  resolution: "@aws-sdk/nested-clients@npm:3.997.40"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.43"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/fetch-http-handler": "npm:^5.6.13"
+    "@smithy/node-http-handler": "npm:^4.9.13"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7b71d7db2b16eab65ca12c5dbee0dc2bd4d4c5278e8b04c53249e0487ed7ba8ff47bcda404365f1dc8cf6ae12baf7ea1d7f89bbce149677c6fb555aabb7a2970
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:^3.996.43":
+  version: 3.996.43
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.43"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/signature-v4": "npm:^5.6.12"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/268608dd5624c6377243903d588b9c13b8de3f3f3e6bea68fc684d125bc92a991fd15a67cb178d1a7a599d0415ce5283f44ba6b96d14909b185d7ff26a9d979b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.1102.0":
+  version: 3.1102.0
+  resolution: "@aws-sdk/token-providers@npm:3.1102.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.5"
+    "@aws-sdk/nested-clients": "npm:^3.997.40"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/761a8a052aeb95ef79503a6ed75a69654f50b21aff409ecc415b162a1fb03d1c6f7357c47707ec0d61beb11fe33a3dbd136e7fd8decf0807e096e7636f754f79
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.974.2":
+  version: 3.974.2
+  resolution: "@aws-sdk/types@npm:3.974.2"
+  dependencies:
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b5ce05e8a4160c545edce1e8527e8ac490be7a6651c736f6811190b5d31d5682699889d51186ab0600df756679bebd2df9d650a17f577523441df803c4fb5777
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:^3.972.37":
+  version: 3.972.37
+  resolution: "@aws-sdk/xml-builder@npm:3.972.37"
+  dependencies:
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/738f9302f495b3b95602641166a4182244add6e9e079201dba7e8994657dd442df0e4cea3355aa8c7d7f08efb385decaaf0b543f03efdb291c118536f36ac1a1
+  languageName: node
+  linkType: hard
+
+"@aws/lambda-invoke-store@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@aws/lambda-invoke-store@npm:0.3.0"
+  checksum: 10c0/b4a2e6b3b5397bc606053e64270d26dc5c886336f88a98cad587b1592eec17058f8fb172f1827a9f0e591f3595cf8f01575c8c9b36cde38c06456f8a65204046
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/code-frame@npm:7.29.0"
@@ -378,6 +633,13 @@ __metadata:
   version: 0.2.3
   resolution: "@bcoe/v8-coverage@npm:0.2.3"
   checksum: 10c0/6b80ae4cb3db53f486da2dc63b6e190a74c8c3cca16bb2733f234a0b6a9382b09b146488ae08e2b22cf00f6c83e20f3e040a2f7894f05c045c946d6a090b1d52
+  languageName: node
+  linkType: hard
+
+"@bufbuild/protobuf@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@bufbuild/protobuf@npm:1.1.1"
+  checksum: 10c0/5c113bc894ff8b81f0f2f9f1cf643f599ce92a93b449c4b1363864be2b68f718dc146e9a8c38d0ac53f773897f4edeb161a43e5af90c69f2e761979ef0ed336d
   languageName: node
   linkType: hard
 
@@ -945,6 +1207,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@observertc/observer-js@npm:1.0.0-beta.12":
+  version: 1.0.0-beta.12
+  resolution: "@observertc/observer-js@npm:1.0.0-beta.12"
+  dependencies:
+    "@bufbuild/protobuf": "npm:1.1.1"
+    events: "npm:^3.3.0"
+    uuid: "npm:^8.3.2"
+  checksum: 10c0/43ef3f9f5539fadb2be523aff4e06e2c08b0462a6998b730481fb33971448e6a2d36204a4f858a856bb8533f625b579c0141bacd426869089247dc48d2bad25d
+  languageName: node
+  linkType: hard
+
 "@pinojs/redact@npm:^0.4.0":
   version: 0.4.0
   resolution: "@pinojs/redact@npm:0.4.0"
@@ -988,6 +1261,69 @@ __metadata:
   dependencies:
     "@sinonjs/commons": "npm:^3.0.1"
   checksum: 10c0/172d21f5200069727f2aa90b35ab60068c1f0652c7d2a43f03bd6c2c2d75b87f4daa9fc7f1402f8c10e0849bb888d15d3364a194339b62307abd3a60cefbb929
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^3.31.1":
+  version: 3.31.1
+  resolution: "@smithy/core@npm:3.31.1"
+  dependencies:
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b953c792dea2c13249b58c1799e4d6aaf21eb1a61e203b83e8e3a9156bebe14ca0585f0ca1ffdf65a193294dddff92a06fbe5c3fbd63ff0c174c88130b47a128
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.4.16":
+  version: 4.4.16
+  resolution: "@smithy/credential-provider-imds@npm:4.4.16"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d03687efbbd1f95e77b7dcb639f24f1600671929627cd743f7acf9640238746664e91f955026f22e235603e10537d46e31fa60f231adbdf37457e53720bc80f9
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^5.6.13":
+  version: 5.6.13
+  resolution: "@smithy/fetch-http-handler@npm:5.6.13"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/028ba8794a6c487ebefae7f40d0124f70e51a1f4e0e465457845c1a44fd607320cd3c64d4a961f159aef59470f0fd43f0d2011b44ee5ef753b7e1dccbdf32ca3
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^4.9.13":
+  version: 4.9.13
+  resolution: "@smithy/node-http-handler@npm:4.9.13"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2f1cdef7a300ad49c3bb698c2ca4773af5e9202d291cfcd855c1b21ab08b3c4ddf56f3722d3251db4e9b7ac39ec1ebc551b156abf3fa70f74c5491bec421f6b5
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^5.6.12":
+  version: 5.6.12
+  resolution: "@smithy/signature-v4@npm:5.6.12"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/33656a41ad61dee16209703cb96b46b29014b3c4fad23bfbb90cdb5415ac06c6577b2bfff958ef9e6c19091364945135a0370b12ddc2daed557c903846e81fe7
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.16.1":
+  version: 4.16.1
+  resolution: "@smithy/types@npm:4.16.1"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e024d9d148deca7bd21d032a9316db109bbe7cf256ffbb8d3981655b9f4f7695c08ec9b87f5a8cf1442e783ba26cb27e4f09603c5bfa3ba1e526c41b1b3e94d2
   languageName: node
   linkType: hard
 
@@ -1739,6 +2075,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bowser@npm:^2.11.0":
+  version: 2.14.1
+  resolution: "bowser@npm:2.14.1"
+  checksum: 10c0/bb69b55ba7f0456e3dc07d0cfd9467f985581f640ba8fd426b08754a6737ee0d6cf3b50607941e5255f04c83075b952ece0599f978dd4d20f1e95461104c5ffd
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.13
   resolution: "brace-expansion@npm:1.1.13"
@@ -2072,6 +2415,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "edumeet-media-node@workspace:."
   dependencies:
+    "@aws-sdk/client-s3": "npm:^3.1102.0"
+    "@observertc/observer-js": "npm:1.0.0-beta.12"
     "@tsconfig/node24": "npm:^24.0.4"
     "@types/debug": "npm:^4.1.13"
     "@types/jest": "npm:^30.0.0"
@@ -2334,6 +2679,13 @@ __metadata:
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 10c0/9a2fe69a41bfdade834ba7c42de4723c97ec776e40656919c62cbd13607c45e127a003f05f724a1ea55e5029a4cf2de444b13009f2af71271e42d93a637137c7
+  languageName: node
+  linkType: hard
+
+"events@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
   languageName: node
   linkType: hard
 
@@ -4653,7 +5005,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.4.0":
+"tslib@npm:^2.4.0, tslib@npm:^2.6.2":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -4830,6 +5182,15 @@ __metadata:
     node-gyp: "npm:latest"
     node-gyp-build: "npm:^4.3.0"
   checksum: 10c0/88c3581c43b9f824f0939b0da0ecf0cf092ff944ace7be517a5459bc18fe1884fc4acda3502ed369b4ce44baf40590a8f1e820c43a425df0758f2ba76b055f77
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<html><head></head><body><h1>observertc stats saving</h1>
<p>Replaces the old SFU-side monitor with the current observertc observer, and makes the resulting call statistics <strong>persistable</strong> — locally, or uploaded to S3 or an HTTP collector.</p>
<blockquote>
<p><strong>Rebased.</strong> This branch has been rebuilt directly on current <code>main</code> rather than rebasing the old one, so the 16 conflicts from the previous review are gone. Every point from that review is addressed below; see <em>Review follow-ups</em> at the end.</p>
</blockquote>
<h2>What changes conceptually</h2>
<p>Before, <code>@observertc/sfu-monitor-js</code> ran inside <code>MediaService</code> and sampled the SFU on a probability (<code>--useObserveRTC</code>, <code>--pollStatsProbability</code>). Nothing was ever written down — samples existed only in memory. That dependency was later removed from <code>main</code> outright (<code>da96886</code>, <code>054aa55</code>) for being deprecated upstream and carrying CVEs.</p>
<p>This PR does <strong>not</strong> bring it back. It adds <code>@observertc/observer-js</code> — a different, actively maintained package — running an <code>Observer</code> that receives <strong>client-side</strong> <code>ClientSample</code> payloads over a DataChannel and correlates them with mediasoup's own router samples, producing artifacts that can be kept:</p>

Artifact | Written when | Content type
-- | -- | --
<clientId>.jsonl | an observed client leaves and its sink closes | application/x-ndjson
call-summary.json | a call closes | application/json
mediasoup-router-<routerId>.json | a router is removed | application/json


<p><strong>No toolchain changes.</strong> <code>main</code>'s Node 24 / <code>@tsconfig/node24</code> / <code>@types/node@^24</code> / <code>eslint@^9</code> / <code>@typescript-eslint@^8</code> are taken as-is, and the Dockerfile, <code>README.md</code> and <code>.gitignore</code> are not modified at all — so <code>node:24-bookworm-slim</code>, <code>COREPACK_ENABLE_DOWNLOAD_PROMPT=0</code> and <code>corepack enable</code> all stay, and there is no CRLF→LF reformatting hiding the real diff. <code>yarn.lock</code> was regenerated against current <code>main</code> rather than merged.</p>
<p><strong><code>enableSctp</code> is <code>main</code>'s.</strong> The branch does not touch <code>src/middlewares/transportMiddleware.ts</code>. The old <code>sctpCapabilities</code> form predated the branch point and was renamed on <code>main</code>; reverting it would have evaluated <code>Boolean(sctpCapabilities)</code> to <code>false</code> and disabled SCTP on every WebRTC transport — taking the <code>observertc-samples</code> DataChannel with it. Nothing in the client or room-server needs a matching change.</p>
<h2>Unit tests</h2>
<p><code>.husky/pre-push</code> runs <code>yarn test:unit</code>, and one suite was already failing on <code>main</code>: <code>__tests__/unit-tests/MediaService.test.ts</code> mocks and imports <code>@observertc/sfu-monitor-js</code>, which <code>main</code> removed from <code>package.json</code> — zero occurrences there today.</p>
<p>That fix is now minimal, as suggested in review: the stale <code>jest.mock</code> and import are deleted, along with the three <code>useObserveRTC</code> / <code>pollStatsProbability</code> tests that asserted on <code>sut.monitor</code> — options <code>main</code> itself deleted, so they cannot pass regardless. Nothing else in <code>__tests__/</code> or <code>__mocks__/</code> is touched.</p>
<p>One config file is added: <code>tsconfig.jest.json</code> sets <code>isolatedModules: true</code> (ts-jest warns <code>TS151002</code> without it and silently downgrades module resolution, which then cannot follow mediasoup's <code>exports</code> map for <code>mediasoup/types</code>), plus a <code>paths</code> mapping for <code>mediasoup/node/lib/*</code> so the existing suites that still import deep paths keep working unchanged.</p>
<p>New coverage: <code>ObserverService.test.ts</code>, <code>uploader/Uploader.test.ts</code>, <code>uploader/samplesUploadUri.test.ts</code> — URI parsing and rejection cases (including rejected userinfo and unknown parameters), factory dispatch, S3 and HTTP upload paths, HTTP retry/backoff and the non-retryable <code>4xx</code> split, <code>deleteAfterUpload</code> in all three states (default, explicit true, explicit false), stats isolation under concurrency, and observer lifecycle/sink wiring. The lazy SDK load is asserted directly — one test checks that no S3 client exists before the first upload, so the deferral can't silently regress.</p>
<h2>Documentation</h2>
<p><code>README.md</code> is intentionally not modified, to keep the CRLF→LF reformatting noted above out of the diff. The two new flags are documented in <code>showUsage()</code> (<code>--help</code>), including the URI grammar and the <code>credentialsEnv</code> convention. Happy to add a README section in this PR or a follow-up, whichever you prefer — appending with the file's existing line endings avoids the conflict.</p>
<h2>Review follow-ups</h2>
<p>Fixed in this branch:</p>
<ul>
<li><strong><code>roomId</code> is no longer trusted.</strong> It arrives in a client-supplied sample attachment, and <code>encodeURIComponent</code> does not escape <code>..</code>, so it could survive into <code>HttpUploader.buildUrl()</code> and let URL normalisation move the POST outside the configured base path. A <code>safeKeySegment()</code> check (<code>^[A-Za-z0-9._-]{1,128}$</code>, with <code>.</code> and <code>..</code> rejected explicitly since they match that class) now guards all three key-building sites; anything else falls back to <code>unknown-room</code> and logs a warning.</li>
<li><strong><code>handleClientUpdated</code> no longer throws.</strong> It reads the client entry first and guards it, so a <code>client-updated</code> without a preceding <code>client-added</code> can't raise a <code>TypeError</code> into the process-level <code>uncaughtException</code> handler and kill the node.</li>
<li><strong><code>DirectTransport</code> is lazy.</strong> It is created on the first <code>observertc-samples</code> DataProducer rather than for every router in <code>getOrCreateRouterPromise()</code>, so nodes with neither flag set pay nothing.</li>
<li><strong>The <code>newworker</code> listener is released.</strong> <code>mediasoup.observer</code> is a process-level singleton that outlives the service, so <code>close()</code> now detaches before <code>super.close()</code>.</li>
<li><strong>The AWS SDK is no longer loaded eagerly.</strong> <code>S3Uploader</code> now keeps only an <code>import type</code> of <code>@aws-sdk/client-s3</code> — erased at compile, so nothing is required at module load — and pulls the real module in via <code>import()</code> on the first upload, memoised so concurrent uploads share one import and one client. Nodes without an <code>s3://</code> upload URI never construct the class and never pay for the SDK. The client is built inside that same load, so <code>S3ClientConfig</code> is assembled in the constructor and applied lazily.</li>
<li><strong><code>@aws-sdk/client-s3</code> is pinned tighter</strong> than the <code>^3.0.0</code> flagged — currently <code>^3.1102.0</code>.</li>
<li><strong><code>deleteAfterUpload</code> now defaults to <code>true</code></strong> when an uploader is configured (see <em>Failure behaviour</em>), so the upload path no longer accumulates files. Automatic retention for the store-only case is deliberately <strong>not</strong> implemented — rationale in that section.</li>
</ul></body></html>